### PR TITLE
feat: add CLI for cross-platform support (Issue #59)

### DIFF
--- a/CLI/CLI.cs
+++ b/CLI/CLI.cs
@@ -1,0 +1,90 @@
+﻿using Z2Randomizer.Core;
+using System.ComponentModel;
+
+namespace Z2Randomizer.CLI;
+class CLI
+{
+	private static Dictionary<string, string> MiscOptions = new Dictionary<string, string>()
+	{
+		{"--remove-flashing-upon-death", "n" },
+		{"--fast-spell-casting", "n"}
+	};
+
+	static bool IsOptionValid(string option)
+	{
+		if (MiscOptions.ContainsKey(option))
+		{
+			return true;
+		}
+		string valid_options = GetMiscOptions();
+		string error_message = String.Format("ERROR: Unknown option '{0}'. Valid options are: \n{1}", option, valid_options);
+		Console.WriteLine(error_message);
+		return false; //Cannot throw exception here since it will be caught in the main function and display the more generic error message.
+	}
+
+	static string GetMiscOptions()
+	{
+		string misc_options = "";
+		foreach (KeyValuePair<string, string> valid_option in MiscOptions)
+		{
+			misc_options += valid_option.Key + "\n";
+		}
+		return misc_options;
+	}
+	static bool ParseStringToBool(string str)
+	{
+		if (str.ToLower() == "y")
+		{
+			return true;
+		}
+		return false;
+	}
+	static void Main(string[] args)
+	{
+		Random random = new Random();
+		try
+		{
+			if (args.Length < 3)
+			{
+				Console.WriteLine("ERROR: Must provide at least 3 arguments: Path to original Zelda 2 ROM, flagset and seed. Please consider running the application from a CLI to provide the arguments.");
+				Console.ReadLine();
+				return;
+			}
+			for (int i = 0; i < args.Length; i++)
+			{
+				if (args[i].Contains("--"))
+				{
+					string option = args[i].Split("=")[0];
+					if (!IsOptionValid(option))
+					{
+						return;
+					}
+					string value = args[i].Split("=")[1];
+					MiscOptions[option] = value;
+				}
+			}
+			string flags = args[1];
+			RandomizerConfiguration config = new RandomizerConfiguration(flags);
+			int seed = int.Parse(args[2]);
+			config.Seed = seed;
+			config.FileName = args[0];
+			config.RemoveFlashing = ParseStringToBool(MiscOptions["--remove-flashing-upon-death"]);
+			config.FastSpellCasting = ParseStringToBool(MiscOptions["--fast-spell-casting"]);
+			BackgroundWorker backgroundWorker = new BackgroundWorker()
+			{
+				WorkerReportsProgress = true,
+				WorkerSupportsCancellation = true
+			};
+			Hyrule hyrule = new Hyrule(config, backgroundWorker, true);
+			Console.WriteLine("ROM generation was successful! You can find your ROM in the same directory as the original ROM. Enjoy!");
+		}
+		catch (Exception e)
+		{
+			Console.WriteLine("ERROR: There was an error during the ROM generation process. Please make sure the path to the file is valid, and that the flagset and seeds are valid according to the randomizer version. Also, if you used any options, please remember the expected format is: '--option=value', where value can be 'y' or 'n' depending on your selection, and please make sure to include them after entering the ROM path file, flagset and seed.");
+			Console.WriteLine("\nValid options are:");
+			string valid_options = GetMiscOptions();
+			Console.WriteLine(valid_options);
+			Console.ReadLine();
+		}
+	}
+}

--- a/CLI/CLI.csproj
+++ b/CLI/CLI.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RandomizerCore\RandomizerCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/RandomizerCore/Flags/FlagBuilder.cs
+++ b/RandomizerCore/Flags/FlagBuilder.cs
@@ -15,7 +15,7 @@ namespace Z2Randomizer.Core.Flags;
 public class FlagBuilder
 {
     public List<bool> bits;
-    private static readonly string ENCODING_TABLE = "ABCDEFGHJKLMNOPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz1234567890!@#$";
+    private static readonly string ENCODING_TABLE = "ABCDEFGHJKLMNOPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz1234567890!@#+";
     public FlagBuilder()
     {
         bits = new List<bool>();

--- a/RandomizerCore/Flags/FlagReader.cs
+++ b/RandomizerCore/Flags/FlagReader.cs
@@ -80,7 +80,7 @@ public class FlagReader
         {'!', 60},
         {'@', 61},
         {'#', 62},
-        {'$', 63},
+        {'+', 63},
     };
 
     private List<bool> bits = new List<bool>();

--- a/RandomizerCore/Hyrule.cs
+++ b/RandomizerCore/Hyrule.cs
@@ -442,7 +442,8 @@ public class Hyrule
             finalRNGState
         ));
         UpdateRom(hash);
-        string newFileName = props.Filename.Substring(0, props.Filename.LastIndexOf("\\") + 1) + "Z2_" + Seed + "_" + Flags + ".nes";
+        char os_sep = Path.DirectorySeparatorChar;
+        string newFileName = props.Filename.Substring(0, props.Filename.LastIndexOf(os_sep) + 1) + "Z2_" + Seed + "_" + Flags + ".nes";
         if (props.saveRom)
         {
             ROMData.Dump(newFileName);

--- a/RandomizerCore/RandomizerConfiguration.cs
+++ b/RandomizerCore/RandomizerConfiguration.cs
@@ -279,7 +279,7 @@ public class RandomizerConfiguration
         {'!', 60},
         {'@', 61},
         {'#', 62},
-        {'$', 63},
+        {'+', 63},
     };
 
 

--- a/RandomizerCore/RandomizerCore.csproj
+++ b/RandomizerCore/RandomizerCore.csproj
@@ -21,7 +21,7 @@
     <PublishWizardCompleted>true</PublishWizardCompleted>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <UseWindowsForms>False</UseWindowsForms>
+    <UseWindowsForms>false</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <PropertyGroup />

--- a/RandomizerCore/RandomizerCore.csproj
+++ b/RandomizerCore/RandomizerCore.csproj
@@ -22,7 +22,6 @@
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>false</UseWindowsForms>
-    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <PropertyGroup />
   <PropertyGroup>

--- a/Z2Randomizer.sln
+++ b/Z2Randomizer.sln
@@ -18,7 +18,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WinFormUI", "WinFormUI\WinFormUI.csproj", "{32152FA5-E875-4D6E-B001-AEC7B8FA58CA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DumpRooms", "DumpRooms\DumpRooms.csproj", "{25230EEF-2BB9-4472-96E3-40AE6EDCF5DE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DumpRooms", "DumpRooms\DumpRooms.csproj", "{25230EEF-2BB9-4472-96E3-40AE6EDCF5DE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CLI", "CLI\CLI.csproj", "{89A427B1-F37C-4AEB-9720-1EBE6E400AE3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -49,6 +51,10 @@ Global
 		{25230EEF-2BB9-4472-96E3-40AE6EDCF5DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{25230EEF-2BB9-4472-96E3-40AE6EDCF5DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{25230EEF-2BB9-4472-96E3-40AE6EDCF5DE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{89A427B1-F37C-4AEB-9720-1EBE6E400AE3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{89A427B1-F37C-4AEB-9720-1EBE6E400AE3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{89A427B1-F37C-4AEB-9720-1EBE6E400AE3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{89A427B1-F37C-4AEB-9720-1EBE6E400AE3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Right now, non-Windows users can't generate the ROM through the UI because it's Windows-only. However, the randomizer itself (Z2RandomizerCore project) is cross-platform, so with this commit, non-Windows users will be able to use a CLI to pass all the arguments necessary to generate the ROM (path to the original ROM, flags and a seed), along with misc options (remove flashing upon death and fast spell casting) and be able to generate the ROM.