### PR TITLE
Mac and Linux fixes for the command line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.nes
 *.user
 .vscode/
+.DS_Store

--- a/Assembler/Assembler.csproj
+++ b/Assembler/Assembler.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ClearScript.V8" Version="7.4.4" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.osx-arm64" Version="7.4.2" Condition="$([MSBuild]::IsOsPlatform('OSX'))" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.osx-arm64" Version="7.4.4" Condition="$([MSBuild]::IsOsPlatform('OSX'))" />
     <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.4.4" Condition="$([MSBuild]::IsOsPlatform('Windows'))" />
   </ItemGroup>
   <ItemGroup>

--- a/Assembler/Assembler.csproj
+++ b/Assembler/Assembler.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ClearScript.V8" Version="7.4.4" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-x64" Version="7.4.4" Condition="$([MSBuild]::IsOsPlatform('Linux'))" />
     <PackageReference Include="Microsoft.ClearScript.V8.Native.osx-arm64" Version="7.4.4" Condition="$([MSBuild]::IsOsPlatform('OSX'))" />
     <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.4.4" Condition="$([MSBuild]::IsOsPlatform('Windows'))" />
   </ItemGroup>

--- a/CommandLine/Models/PlayerOptions.cs
+++ b/CommandLine/Models/PlayerOptions.cs
@@ -14,11 +14,11 @@ namespace CommandLine.Models
 
         public bool RemoveFlashingUponDeath { get; set; }
 
-        public string Sprite { get; set; }
+        public string? Sprite { get; set; }
 
-        public string TunicColor { get; set; }
+        public string? TunicColor { get; set; }
 
-        public string ShieldTunicColor { get; set; }
+        public string? ShieldTunicColor { get; set; }
 
         [JsonConverter(typeof(StringEnumConverter))]
         public BeamSprite BeamSprite { get; set; }

--- a/CommandLine/Program.cs
+++ b/CommandLine/Program.cs
@@ -12,16 +12,16 @@ public class Program
         => CommandLineApplication.Execute<Program>(args);
 
     [Option(ShortName = "f", Description = "Flag string")]
-    public string Flags { get; }
+    public string? Flags { get; }
 
     [Option(ShortName = "r", Description = "Path to the base ROM file")]
-    public string Rom { get; }
+    public string? Rom { get; }
 
     [Option(ShortName = "s", Description = "[Optional] Seed used to generate the shuffled ROM")]
     public int? Seed { get; set; }
 
     [Option(ShortName = "po", Description = "[Optional] Specifies a player options file to use for misc settings")]
-    public string PlayerOptions { get; }
+    public string? PlayerOptions { get; }
 
     private RandomizerConfiguration? configuration;
 
@@ -65,6 +65,11 @@ public class Program
         {
             var playerOptionsService = new PlayerOptionsService();
             var playerOptions = playerOptionsService.LoadFromFile(this.PlayerOptions);
+            if (playerOptions == null)
+            {
+                throw new Exception("Could not load player options");
+            }
+
             playerOptionsService.ApplyOptionsToConfiguration(playerOptions, configuration);
         }
         catch (Exception exception)
@@ -80,10 +85,10 @@ public class Program
 
     public void Randomize()
     {
-        Exception generationException = null;
+        Exception? generationException = null;
         var worker = new BackgroundWorker();
-        worker.DoWork += new DoWorkEventHandler(RandomizationWorker);
-        worker.ProgressChanged += new ProgressChangedEventHandler(BackgroundWorker1_ProgressChanged);
+        worker.DoWork += new DoWorkEventHandler(RandomizationWorker!);
+        worker.ProgressChanged += new ProgressChangedEventHandler(BackgroundWorker1_ProgressChanged!);
         worker.WorkerReportsProgress = true;
         worker.WorkerSupportsCancellation = true;
         worker.RunWorkerCompleted += (completed_sender, completed_event) =>
@@ -110,10 +115,10 @@ public class Program
 
     private void RandomizationWorker(object sender, DoWorkEventArgs e)
     {
-        BackgroundWorker worker = sender as BackgroundWorker;
+        BackgroundWorker? worker = sender as BackgroundWorker;
 
         new Hyrule(this.configuration, worker, true);
-        if (worker.CancellationPending)
+        if (worker!.CancellationPending)
         {
             e.Cancel = true;
         }

--- a/CommandLine/Program.cs
+++ b/CommandLine/Program.cs
@@ -1,5 +1,6 @@
 ﻿using CommandLine;
 using McMaster.Extensions.CommandLineUtils;
+using NLog;
 using System.ComponentModel;
 using Z2Randomizer.Core;
 
@@ -24,11 +25,13 @@ public class Program
 
     private RandomizerConfiguration? configuration;
 
+    private static readonly Logger logger = LogManager.GetCurrentClassLogger();
+
     private int OnExecute()
     {
         if (Flags == null || Flags == string.Empty)
         {
-            Console.WriteLine("The flag string is required");
+            logger.Error("The flag string is required");
             return -1;
         }
 
@@ -43,24 +46,32 @@ public class Program
 
         if (Rom == null || Rom == string.Empty)
         {
-            Console.WriteLine("The ROM path is required");
+            logger.Error("The ROM path is required");
             return -2;
         } 
         else if (!File.Exists(Rom))
         {
-            Console.WriteLine($"The specified ROM file does not exist: {Rom}");
+            logger.Error($"The specified ROM file does not exist: {Rom}");
             return -3;
         }
 
         this.configuration.FileName = Rom;
 
-        Console.WriteLine($"Flags: {Flags}");
-        Console.WriteLine($"Rom: {Rom}");
-        Console.WriteLine($"Seed: {Seed}");
+        logger.Info($"Flags: {Flags}");
+        logger.Info($"Rom: {Rom}");
+        logger.Info($"Seed: {Seed}");
 
-        var playerOptionsService = new PlayerOptionsService();
-        var playerOptions = playerOptionsService.LoadFromFile(this.PlayerOptions);
-        playerOptionsService.ApplyOptionsToConfiguration(playerOptions, configuration);
+        try
+        {
+            var playerOptionsService = new PlayerOptionsService();
+            var playerOptions = playerOptionsService.LoadFromFile(this.PlayerOptions);
+            playerOptionsService.ApplyOptionsToConfiguration(playerOptions, configuration);
+        }
+        catch (Exception exception)
+        {
+            logger.Fatal(exception);
+            return -4;
+        }
 
         Randomize();
 
@@ -88,12 +99,12 @@ public class Program
 
         if (generationException == null)
         {
-            Console.WriteLine("File " + "Z2_" + this.Seed + "_" + this.Flags + ".nes" + " has been created!");
+            logger.Info("File " + "Z2_" + this.Seed + "_" + this.Flags + ".nes" + " has been created!");
         }
         else
         {
-            Console.Error.WriteLine("An exception occurred generating the rom: \n" + generationException.Message);
-            Console.Error.WriteLine(generationException.StackTrace);
+            logger.Error("An exception occurred generating the rom");
+            logger.Fatal(generationException);
         }
     }
 
@@ -112,35 +123,35 @@ public class Program
     {
         if (eventArgs.ProgressPercentage == 2)
         {
-            Console.WriteLine("Generating Western Hyrule");
+            logger.Info("Generating Western Hyrule");
         }
         else if (eventArgs.ProgressPercentage == 3)
         {
-            Console.WriteLine("Generating Death Mountain");
+            logger.Info("Generating Death Mountain");
         }
         else if (eventArgs.ProgressPercentage == 4)
         {
-            Console.WriteLine("Generating East Hyrule");
+            logger.Info("Generating East Hyrule");
         }
         else if (eventArgs.ProgressPercentage == 5)
         {
-            Console.WriteLine("Generating Maze Island");
+            logger.Info("Generating Maze Island");
         }
         else if (eventArgs.ProgressPercentage == 6)
         {
-            Console.WriteLine("Shuffling Items and Spells");
+            logger.Info("Shuffling Items and Spells");
         }
         else if (eventArgs.ProgressPercentage == 7)
         {
-            Console.WriteLine("Running Seed Completability Checks");
+            logger.Info("Running Seed Completability Checks");
         }
         else if (eventArgs.ProgressPercentage == 8)
         {
-            Console.WriteLine("Generating Hints");
+            logger.Info("Generating Hints");
         }
         else if (eventArgs.ProgressPercentage == 9)
         {
-            Console.WriteLine("Finishing up");
+            logger.Info("Finishing up");
         }
     }
 }

--- a/RandomizerCore/nlog.config
+++ b/RandomizerCore/nlog.config
@@ -3,16 +3,16 @@
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xsi:schemaLocation="NLog NLog.xsd"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       autoReload="true"
-      internalLogFile="%localappdata%\Z2Randomizer\internal.log"
+      internalLogFile="internal.log"
       internalLogLevel="info" >
 
   <!-- the targets to write to -->
   <targets>
     <!-- write logs to file -->
-    <target xsi:type="File" name="file" fileName="${environment:localappdata}\Z2Randomizer\log.log"
-            layout="${longdate}|${event-properties:item=EventId_Id}|${uppercase:${level}}|${logger}|${message} ${exception:format=StackTrace}" />
+    <target xsi:type="File" name="file" fileName="${specialfolder:folder=LocalApplicationData}/Z2Randomizer/z2r.log"
+            layout="${longdate}|${event-properties:item=EventId_Id}|${uppercase:${level}}|${logger}| ${message} ${exception:format=StackTrace}" />
     <target xsi:type="Console" name="console"
-            layout="${longdate}|${event-properties:item=EventId_Id}|${uppercase:${level}}|${logger}|${message} ${exception:format=StackTrace}" />
+            layout="${message} ${exception:format=StackTrace}" />
     <target name="debugger" xsi:type="Debugger" layout="${logger}::${message}"/>
   </targets>
 


### PR DESCRIPTION
- Cleaned up spurious log files for non-Windows OSes
- Changed the console logging to use the logger so it's also logged to the log file
- Fixed some warnings around null safety checks
- Fixed a runtime exception based on incorrect version of Microsoft.ClearScript.V8 for Macos