### PR TITLE
Update file operations on room configuration files to safekt fall back

### DIFF
--- a/RandomizerCore/Hyrule.cs
+++ b/RandomizerCore/Hyrule.cs
@@ -535,7 +535,7 @@ public class Hyrule
             //TODO: Since the modularization split, ExecutingAssembly's version data always returns 0.0.0.0
             //Eventually we need to turn this back into a read from the assembly, but for now I'm just adding an awful hard write of the version.
             "4.3.2" +
-            File.ReadAllText(config.GetRoomsFile()) +
+            Util.ReadAllTextFromFile(config.GetRoomsFile()) +
             finalRNGState
         ));
         UpdateRom(hash);

--- a/RandomizerCore/Sidescroll/PalaceRooms.cs
+++ b/RandomizerCore/Sidescroll/PalaceRooms.cs
@@ -26,9 +26,9 @@ public class PalaceRooms
 
     static PalaceRooms()
     {
-        if (File.Exists("PalaceRooms.json"))
+        if (Util.FileExists("PalaceRooms.json"))
         {
-            string roomsJson = File.ReadAllText("PalaceRooms.json");
+            string roomsJson = Util.ReadAllTextFromFile("PalaceRooms.json");
             byte[] hash = MD5.HashData(Encoding.UTF8.GetBytes(Regex.Replace(roomsJson, @"[\n\r\f]", "")));
             if (roomsMD5 != Convert.ToBase64String(hash))
             {
@@ -54,9 +54,9 @@ public class PalaceRooms
             throw new Exception("Unable to find PalaceRooms.json. Consider reinstalling or contact Ellendar.");
         }
 
-        if (File.Exists("CustomRooms.json"))
+        if (Util.FileExists("CustomRooms.json"))
         {
-            string roomsJson = File.ReadAllText("CustomRooms.json");
+            string roomsJson = Util.ReadAllTextFromFile("CustomRooms.json");
             byte[] hash = MD5.HashData(Encoding.UTF8.GetBytes(Regex.Replace(roomsJson, @"[\n\r\f]", "")));
 
             dynamic rooms = JsonConvert.DeserializeObject(roomsJson);

--- a/RandomizerCore/Util.cs
+++ b/RandomizerCore/Util.cs
@@ -88,10 +88,47 @@ public class Util
         (p2.Item, p1.Item) = (p1.Item, p2.Item);
         (p2.Name, p1.Name) = (p1.Name, p2.Name);
     }
+
     public static string ByteArrayToHexString(byte[] bytes)
     {
         string hex = BitConverter.ToString(bytes);
         return hex.Replace("-", "");
+    }
+
+    /// <summary>
+    /// Cross platform safe method for finding files that defaults to current working directory with a fallback of the directory
+    /// that the executable is running from.
+    /// </summary>
+    /// <param name="fileName">The </param>
+    /// <returns>Whether the file exists in the current working directory or in the directory of the executable.</returns>
+    public static bool FileExists(string fileName)
+    {
+        bool exists = File.Exists(fileName);
+        if (!exists)
+        {
+            string absoluteFilePath = FilePathFromAssemblyLocation(fileName);
+            exists = File.Exists(absoluteFilePath);
+        }
+
+        return exists;
+    }
+
+    public static string ReadAllTextFromFile(string fileName)
+    {
+        string fileToLoad = fileName;
+        if (!File.Exists(fileName))
+        {
+            fileToLoad = FilePathFromAssemblyLocation(fileName);
+        }
+
+        return File.ReadAllText(fileToLoad);
+    }
+
+    private static string FilePathFromAssemblyLocation(string fileName)
+    {
+        string executingDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+
+        return Path.Combine(executingDirectory, fileName);
     }
 
     /// <summary>


### PR DESCRIPTION
FileExists and ReadAllTextFromFile operations on the PalaceRooms.json or CustomRooms.json will first try the current working directory and fall back to the directory the executable is in.