### PR TITLE
Make music loading error messages more helpful for non-programmers

### DIFF
--- a/RandomizerCore/Music.cs
+++ b/RandomizerCore/Music.cs
@@ -6,6 +6,7 @@ using FtRandoLib.Library;
 using FtRandoLib.Utility;
 using NLog;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -245,7 +246,28 @@ internal class MusicRandomizer
         foreach (var libPath in _libPaths)
         {
             string libData = File.ReadAllText(libPath, Encoding.UTF8);
-            ftSongs.AddRange(_imptr.LoadFtJsonLibrarySongs(libData, opts));
+
+            try
+            {
+                ftSongs.AddRange(_imptr.LoadFtJsonLibrarySongs(libData, opts));
+            }
+            catch (ParsingError ex)
+            {
+                StringBuilder sb = new();
+                sb.AppendLine($"Error loading custom music from '{libPath}'");
+
+                string? atStr = ex.AtString;
+                if (atStr is not null)
+                    sb.AppendLine(atStr);
+
+                sb.AppendLine();
+
+                sb.AppendLine(ex.Message);
+                if (ex.Submessage is not null)
+                    sb.AppendLine(ex.Submessage);
+
+                throw new Exception(sb.ToString(), ex);
+            }
         }
 
         List<ISong> songs = new();

--- a/RandomizerCore/RandomizerCore.csproj
+++ b/RandomizerCore/RandomizerCore.csproj
@@ -68,7 +68,6 @@
     <WCFMetadata Include="Service References\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SD.Tools.Algorithmia" Version="1.4.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.421302">


### PR DESCRIPTION
Error handling (and especially error reporting) in FtRandoLib was kind of left as a to-do, as it was not expected that non-developers would be creating music libraries. When Z2R decided to not have standard libraries but allow users to create their own, errors resulting in extremely unhelpful messages. 

This PR (in combination with changes to FtRandoLib) remedies that by providing more helpful errors and error messages that should be sufficient to quickly find the cause of most common library errors.