### PR TITLE
Remove MacOS 12 From GitHub Build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,6 @@ jobs:
         platform: [
           { os: windows-latest, arch: x64 },
           { os: windows-latest, arch: browser-wasm },
-          { os: macos-12, arch: x64 },
           { os: macos-14, arch: arm64 },
           { os: ubuntu-latest, arch: x64 },
         ]


### PR DESCRIPTION
Get rid of it as it's not even supported and causes precommits to always fail.