### PR TITLE
Better validation & minor room fixes that I found

### DIFF
--- a/RandomizerCore/Enemies.cs
+++ b/RandomizerCore/Enemies.cs
@@ -139,7 +139,7 @@ Towns
 /// </summary>
 public static class EnemiesShared
 {
-    public const int FAIRT = 0x00;
+    public const int FAIRY = 0x00;
     public const int LOCKED_DOOR = 0x02;
     public const int MYU = 0x03;
     public const int BOT = 0x04;

--- a/RandomizerCore/PalaceRooms.json
+++ b/RandomizerCore/PalaceRooms.json
@@ -2377,6 +2377,7 @@
     "palaceNumber": null,
     "requirements": [
     ],
+    "suppressWarning": ["MultipleItemsOnPage"],
     "sideviewData": "19600E10E100D0086001A80F086702D10ED60860016F02D10E"
   },
   {
@@ -3827,6 +3828,7 @@
     "palaceNumber": 7,
     "requirements": [
     ],
+    "suppressWarning": ["DropTilesInNonDropRoom"],
     "sideviewData": "166005081023D408609E6F9FDD80A03F639CB1B1DC0E"
   },
   {
@@ -4222,6 +4224,7 @@
     "palaceNumber": 7,
     "requirements": [
     ],
+    "suppressWarning": ["DropTilesInNonDropRoom"],
     "sideviewData": "4B600E08D408609B42004400440062B3420062C942004400929542006093802364B34000B006B106B106B106410060C7B006B106B106B1064100B006B106B106B106D10FD408920F12D80E"
   },
   {
@@ -6146,6 +6149,7 @@
     "palaceNumber": null,
     "requirements": [
     ],
+    "suppressWarning": ["DropTilesInNonDropRoom"],
     "sideviewData": "2960030804FE802F96C3240705FD802D95C3730F0C06FE802E130794C3A40704FB802B330792C3D703"
   },
   {
@@ -6666,6 +6670,7 @@
     "palaceNumber": null,
     "requirements": [
     ],
+    "suppressWarning": ["DropTilesInNonDropRoom"],
     "sideviewData": "2960030804FE802F96C3240705FD802D95C3730F0C06FE802E130794C3A40704FB802B330792C3D703"
   },
   {
@@ -6692,6 +6697,7 @@
     "palaceNumber": null,
     "requirements": [
     ],
+    "suppressWarning": ["DropTilesInNonDropRoom"],
     "sideviewData": "2960030804FE802F96C3240705FD802D95C3730F0C06FE802E130794C3A40704FB802B330792C3D703"
   },
   {
@@ -6718,6 +6724,7 @@
     "palaceNumber": null,
     "requirements": [
     ],
+    "suppressWarning": ["DropTilesInNonDropRoom"],
     "sideviewData": "2960030804FE802F96C3240705FD802D95C3730F0C06FE802E130794C3A40704FB802B330792C3D703"
   },
   {
@@ -6770,6 +6777,7 @@
     "palaceNumber": null,
     "requirements": [
     ],
+    "suppressWarning": ["MultipleItemsOnPage"],
     "sideviewData": "2E600F10D1034001D300F01FA05F622C940F0AAA72D305F05070F1D400F01F622C46B1970F08F11F612C46B1D905"
   },
   {
@@ -7062,6 +7070,7 @@
     "palaceNumber": null,
     "requirements": [
     ],
+    "suppressWarning": ["MultipleItemsOnPage"],
     "sideviewData": "19600E10E100D0086001A80F086702D10ED60860016F02D10E"
   },
   {
@@ -7400,12 +7409,13 @@
     "linkedRoomName": null,
     "map": 2,
     "memoryAddress": 67379,
-    "name": "",
+    "name": "dusterRoomJam outdoors key",
     "palaceGroup": null,
     "palaceNumber": null,
     "requirements": [
     ],
-    "sideviewData": "33609F00D00EB077D2E04007470713073807362BA02B2208402750C3902757C3650721075C081507A043820F0890417109D1FF"
+    "suppressWarning": ["MultipleItemsOnPage"],
+    "sideviewData": "33609F00D00EB077D2E04007470713073807362BA02B2208402750C3902757C3650721075C081507A033820F0890317109D1FF"
   },
   {
     "author": "dusterRoomJam",
@@ -11912,6 +11922,7 @@
     "palaceNumber": null,
     "requirements": [
     ],
+    "suppressWarning": ["MultipleItemsOnPage"],
     "sideviewData": "20600E10D0804900460046004600D66B6202D16E8105F25000F1B071D56B6001"
   },
   {
@@ -13446,6 +13457,7 @@
     "palaceNumber": 7,
     "requirements": [
     ],
+    "suppressWarning": ["DropTilesInNonDropRoom"],
     "sideviewData": "18600E08E100D080609CA03FBAB1639FD3086D9EDF051023"
   },
   {
@@ -14370,6 +14382,7 @@
     "palaceNumber": null,
     "requirements": [
     ],
+    "suppressWarning": ["MultipleItemsOnPage"],
     "sideviewData": "19600E08D408208E70019573880F0890717109D10FE300DE0F"
   },
   {
@@ -14811,8 +14824,7 @@
     "palaceNumber": null,
     "requirements": [
     ],
-    "sideviewData": "21600009990F0181409040880597737271527770779077F8505225565455245554",
-	"suppressValidation":true
+    "sideviewData": "21600009990F0181409040880597737271527770779077F8505225565455245554"
   },
   {
     "author": "aaron2u2",
@@ -16605,7 +16617,7 @@
     "hasDrop": false,
     "elevatorScreen": -1,
     "requirements": [],
-    "isDropZone": true,
+    "isDropZone": false,
     "hasItem": false,
     "enemies": "090F0F5E596A8400CF",
     "sideviewData": "2E601E08D280A4236131F31F92355130513F9633F61F903576319233523F9435F21B963354320223A023F250D60E",
@@ -16619,8 +16631,7 @@
     "isEntrance": false,
     "palaceNumber": null,
     "linkedRoomName": null,
-    "isUpDownReversed": false,
-	"suppressValidation": true
+    "isUpDownReversed": false
   },
   {
     "bitmask": "0F",
@@ -16995,8 +17006,7 @@
     "isEntrance": false,
     "palaceNumber": null,
     "linkedRoomName": null,
-    "isUpDownReversed": false,
-	"suppressValidation": true
+    "isUpDownReversed": false
   },
   {
     "bitmask": "0F",
@@ -17546,8 +17556,7 @@
     "isEntrance": false,
     "palaceNumber": null,
     "linkedRoomName": null,
-    "isUpDownReversed": false,
-	"suppressValidation": true
+    "isUpDownReversed": false
   },
   {
     "bitmask": "0F",
@@ -18571,7 +18580,6 @@
     "isEntrance": false,
     "palaceNumber": null,
     "linkedRoomName": null,
-	"suppressValidation" : true,
     "isUpDownReversed": false
   },
   {
@@ -18758,6 +18766,7 @@
     "hasDrop": false,
     "elevatorScreen": 1,
     "requirements": [],
+    "suppressWarning": ["DropTilesInNonDropRoom", "ElevatorEnemy"],
     "isDropZone": true,
     "hasItem": false,
     "enemies": "0501855793",
@@ -18786,7 +18795,7 @@
     "isDropZone": true,
     "hasItem": false,
     "enemies": "0D8751795170D182D164D16551",
-    "sideviewData": "56600F08D20EF550B006B106D4884300D50820D831306030903021D821305030803021D841D07030A03021D8D188450044004400D70820D841D07030A03021D821305030803021D831D06030903021D8D1884400F400",
+    "sideviewData": "54600F08D20EF550B006B106D4884300D50820D831306030903021D821305030803021D841D07030A03021D8D188450044004400D70820D841D07030A03021D821305030803021D831D06030903021D8D1884400",
     "hasBoss": false,
     "isBossRoom": false,
     "name": "Drop waffles",

--- a/RandomizerCore/Sidescroll/Room.cs
+++ b/RandomizerCore/Sidescroll/Room.cs
@@ -126,7 +126,7 @@ public class Room : IJsonOnDeserialized
     public Room MergedPrimary { get; set; }
     [JsonIgnore]
     public Room MergedSecondary { get; set; }
-    public bool SuppressValidation { get; set; } = false;
+    public List<string> SuppressWarning { get; set; } = [];
 
     //The json loads the fields the analyzer says aren't loaded. Source: trust me bro
     //But seriously eventually put some validation here.

--- a/RandomizerCore/Sidescroll/SideviewEnums.cs
+++ b/RandomizerCore/Sidescroll/SideviewEnums.cs
@@ -219,6 +219,21 @@ public static class PalaceObjectExtensions
                 return false;
         }
     }
+
+    public static bool IsPit(SideviewMapCommand<PalaceObject> command)
+    {
+        switch (command.Id)
+        {
+            case PalaceObject.HorizontalPitOrLava:
+            case PalaceObject.WalkThruBricks:
+            case PalaceObject.VerticalPit1:
+            case PalaceObject.VerticalPit2:
+            case PalaceObject.HorizontalPit:
+                return true;
+            default:
+                return false;
+        }
+    }
 }
 
 public static class GreatPalaceObjectExtensions
@@ -333,6 +348,18 @@ public static class GreatPalaceObjectExtensions
             case GreatPalaceObject.BreakableBlock1:
             case GreatPalaceObject.BreakableBlock2:
             case GreatPalaceObject.BreakableBlockVertical:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public static bool IsPit(SideviewMapCommand<GreatPalaceObject> command)
+    {
+        switch (command.Id)
+        {
+            case GreatPalaceObject.ElevatorShaft:
+            case GreatPalaceObject.WalkThruBricks:
                 return true;
             default:
                 return false;

--- a/RandomizerCore/Sidescroll/SideviewMapCommand.cs
+++ b/RandomizerCore/Sidescroll/SideviewMapCommand.cs
@@ -23,6 +23,11 @@ public class SideviewMapCommand<T> where T : Enum
     /// </summary>
     public int AbsX { get; set; }
 
+    public int Page
+    {
+        get => AbsX / 16;
+    }
+
     /// <summary>
     /// Create from an array of bytes making up a single map command.
     /// </summary>
@@ -77,16 +82,16 @@ public class SideviewMapCommand<T> where T : Enum
     /// </summary>
     public int Y
     {
-        get { return (Bytes[0] & 0xF0) >> 4; }
-        set { Bytes[0] = (byte)((value << 4) + (Bytes[0] & 0x0F)); }
+        get => (Bytes[0] & 0xF0) >> 4;
+        set { Bytes[0] = (byte)((value << 4) | (Bytes[0] & 0x0F)); }
     }
 
     /// <summary>
     /// Access the relative x position of the map command, the second 4 bits.
     /// </summary>
     public int RelX {
-        get { return Bytes[0] & 0x0F; }
-        set { Bytes[0] = (byte)((Bytes[0] & 0xF0) + (value & 0x0F)); }
+        get => Bytes[0] & 0x0F;
+        set { Bytes[0] = (byte)((Bytes[0] & 0xF0) | (value & 0x0F)); }
     }
 
     /// <summary>
@@ -94,7 +99,7 @@ public class SideviewMapCommand<T> where T : Enum
     /// </summary>
     public T Id
     {
-        get { return (T)Enum.ToObject(typeof(T), (Bytes[1] < 0x10) ? Bytes[1] : (Bytes[1] & 0xF0)); }
+        get => (T)Enum.ToObject(typeof(T), (Bytes[1] < 0x10) ? Bytes[1] : (Bytes[1] & 0xF0));
         set { Bytes[1] = Convert.ToByte(value); }
     }
 
@@ -280,6 +285,29 @@ public class SideviewMapCommand<T> where T : Enum
                         return PalaceObjectExtensions.IsBreakable((this as SideviewMapCommand<PalaceObject>)!);
                     case SideviewMapCommand<GreatPalaceObject>:
                         return GreatPalaceObjectExtensions.IsBreakable((this as SideviewMapCommand<GreatPalaceObject>)!);
+                    default:
+                        throw new NotImplementedException();
+                }
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+
+    public bool IsPit
+    {
+        get
+        {
+            if (Y < 13)
+            {
+                switch (this)
+                {
+                    case SideviewMapCommand<PalaceObject>:
+                        return PalaceObjectExtensions.IsPit((this as SideviewMapCommand<PalaceObject>)!);
+                    case SideviewMapCommand<GreatPalaceObject>:
+                        return GreatPalaceObjectExtensions.IsPit((this as SideviewMapCommand<GreatPalaceObject>)!);
                     default:
                         throw new NotImplementedException();
                 }

--- a/ValidateRooms/Program.cs
+++ b/ValidateRooms/Program.cs
@@ -2,6 +2,7 @@
 
 using System.Text;
 using System.Text.Json;
+using RandomizerCore;
 using RandomizerCore.Sidescroll;
 
 StringBuilder sb = new StringBuilder("");
@@ -34,7 +35,7 @@ void ValidateRoomsForFile(string filename)
         {
             // From testing: a room with 12 enemies crashes the game. 11 seemed to work.
             // In the vanilla palace rooms, the max amount of enemies is 9
-            var ee = new EnemiesEditable(room.Enemies);
+            var ee = new EnemiesEditable<EnemiesPalace125>(room.Enemies);
             if (ee.Enemies.Count > 9) { sb.AppendLine($"{GetName(room)}: Room has too many enemies ({ee.Enemies.Count})."); }
         }
         catch (Exception e) { sb.AppendLine($"{GetName(room)}: Room enemies data error. {e.Message}"); }


### PR DESCRIPTION
[Clean up and improve ValidateRooms](https://github.com/Ellendar/Z2Randomizer/commit/ce24ce18b7665c16d29d387a9de6ee5fec4fda7a) 

- Allow suppressing warnings based on a warning ID, instead of suppressing
  warnings for the entire room - which was very error-prone.
- Now validate linked rooms.
- Utilize an exact solid block grid for better calculations.
- Check for multiple items in a single page.
- Add validation for elevator param.

[Update PalaceRooms with some minor changes](https://github.com/Ellendar/Z2Randomizer/commit/b4279525d9a9ac2b3a0fc64f32d2b51a5290fb1f) 

- Remove suppressValidation, add suppressWarning

- Drop waffles room: Remove illegal map command at the end. It had a window map command at y = 15 which is not valid.
- aaron jam 4_4 P5_M49: Change to not be a drop room (had lava over drop and suppressValidation)
- dusterRoomJam outdoors key: Name the room and change the steel bricks under the key (almost looked like an item room)
