### PR TITLE
Enemy refactor and small improvements

### DIFF
--- a/RandomizerCore/Enemies.cs
+++ b/RandomizerCore/Enemies.cs
@@ -21,30 +21,98 @@ public class Enemies
 
 
 
+    public static readonly EnemiesPalace125[] Palace125SmallEnemies = [
+        EnemiesPalace125.MYU,
+        EnemiesPalace125.BOT,
+        EnemiesPalace125.ROPE_STATIONARY,
+        EnemiesPalace125.ROPE_MOVING,
+    ];
+    public static readonly EnemiesPalace125[] Palace125LargeEnemies = [
+        EnemiesPalace125.TINSUIT,
+        EnemiesPalace125.ORANGE_IRON_KNUCKLE,
+        EnemiesPalace125.RED_IRON_KNUCKLE,
+        EnemiesPalace125.BLUE_IRON_KNUCKLE,
+        EnemiesPalace125.MAGO,
+        EnemiesPalace125.GUMA,
+        EnemiesPalace125.RED_STALFOS,
+        EnemiesPalace125.BLUE_STALFOS,
+    ];
+    public static readonly EnemiesPalace125[] Palace125GroundEnemies = [.. Palace125SmallEnemies, .. Palace125LargeEnemies];
+    public static readonly EnemiesPalace125[] Palace125FlyingEnemies = [
+        EnemiesPalace125.SLOW_BUBBLE,
+        EnemiesPalace125.ORANGE_MOA,
+        EnemiesPalace125.FAST_BUBBLE,
+    ];
+    public static readonly EnemiesPalace125[] Palace125Generators = [
+        EnemiesPalace125.TINSUIT_GENERATOR,
+        EnemiesPalace125.BAGO_BAGO_GENERATOR,
+        EnemiesPalace125.WOLF_HEAD_GENERATOR,
+        EnemiesPalace125.BLUE_DRAGON_HEAD_GENERATOR,
+    ];
 
-	public static readonly int[] Palace125Enemies = new int[] { 0x03, 0x04, 0x0C, 0x11, 0x12, 0x18, 0x19, 0x1A, 0x1D, 0x1E, 0x1F, 0x23 };
-    public static readonly int[] Palace125FlyingEnemies = new int[] { 0x06, 0x07, 0x0E };
-    public static readonly int[] Palace125Generators = new int[] { 0x0B, 0x0F, 0x1B, 0x0A };
-    public static readonly int[] Palace125SmallEnemies = new int[] { 0x03, 0x04, 0x11, 0x12 };
-    public static readonly int[] Palace125LargeEnemies = new int[] { 0x0C, 0x18, 0x19, 0x1A, 0x1D, 0x1E, 0x1F, 0x23 };
 
-    public static readonly int[] Palace346Enemies = new int[] { 0x03, 0x04, 0x0C, 0x11, 0x18, 0x19, 0x1A, 0x1D, 0x1F, 0x1E, 0x23 };
-    public static readonly int[] Palace346FlyingEnemies = new int[] { 0x06, 0x07, 0x0E };
-    public static readonly int[] Palace346Generators = new int[] { 0x0B, 0x0F, 0x1B  };
-    public static readonly int[] Palace346SmallEnemies = new int[] { 0x03, 0x04, 0x11 };
-    public static readonly int[] Palace346LargeEnemies = new int[] { 0x0C, 0x18, 0x19, 0x1A, 0x1D, 0x1F, 0x1E, 0x23 };
+    public static readonly EnemiesPalace346[] Palace346SmallEnemies = [
+        EnemiesPalace346.MYU,
+        EnemiesPalace346.BOT,
+        EnemiesPalace346.ROPE,
+    ];
+    public static readonly EnemiesPalace346[] Palace346LargeEnemies = [
+        EnemiesPalace346.TINSUIT,
+        EnemiesPalace346.ORANGE_IRON_KNUCKLE,
+        EnemiesPalace346.RED_IRON_KNUCKLE,
+        EnemiesPalace346.BLUE_IRON_KNUCKLE,
+        EnemiesPalace346.WIZARD,
+        EnemiesPalace346.DOOMKNOCKER,
+        EnemiesPalace346.RED_STALFOS,
+        EnemiesPalace346.BLUE_STALFOS,
+    ];
+    public static readonly EnemiesPalace346[] Palace346GroundEnemies = [.. Palace346SmallEnemies, .. Palace346LargeEnemies];
+    public static readonly EnemiesPalace346[] Palace346FlyingEnemies = [
+        EnemiesPalace346.SLOW_BUBBLE,
+        EnemiesPalace346.ORANGE_MOA,
+        EnemiesPalace346.FAST_BUBBLE,
+    ];
+    public static readonly EnemiesPalace346[] Palace346Generators = [
+        EnemiesPalace346.TINSUIT_GENERATOR,
+        EnemiesPalace346.BLUE_DRAGON_HEAD_GENERATOR,
+        EnemiesPalace346.WOLF_HEAD_GENERATOR,
+    ];
 
-    public static readonly int[] GPEnemies = new int[] { 0x03, 0x04, 0x11, 0x12, 0x18, 0x19, 0x1A, 0x1D };
-    public static readonly int[] GPFlyingEnemies = new int[] { 0x06, 0x14, 0x15, 0x17, 0x1E };
-    public static readonly int[] GPGenerators = new int[] { 0x0B, 0x0C, 0x0F, 0x16 };
-    public static readonly int[] GPSmallEnemies = new int[] { 03, 0x04, 0x11, 0x12 };
-    public static readonly int[] GPLargeEnemies = new int[] { 0x18, 0x19, 0x1A, 0x1D };
 
-	public static readonly int[] StandardPalaceEnemies = Palace125Enemies.Union(Palace346Enemies).ToArray();
-    public static readonly int[] StandardPalaceFlyingEnemies = Palace125FlyingEnemies.Union(Palace346FlyingEnemies).ToArray();
-    public static readonly int[] StandardPalaceGenerators = Palace125Generators.Union(Palace346Generators).ToArray();
-    public static readonly int[] StandardPalaceSmallEnemies = Palace125SmallEnemies.Union(Palace346SmallEnemies).ToArray();
-    public static readonly int[] StandardPalaceLargeEnemies = Palace125LargeEnemies.Union(Palace346LargeEnemies).ToArray();
+    public static readonly EnemiesGreatPalace[] GPSmallEnemies = [
+        EnemiesGreatPalace.MYU,
+        EnemiesGreatPalace.BOT,
+        EnemiesGreatPalace.ROPE_STATIONARY,
+        EnemiesGreatPalace.ROPE_MOBILE,
+    ];
+    public static readonly EnemiesGreatPalace[] GPLargeEnemies = [
+        EnemiesGreatPalace.ORANGE_FOKKA,
+        EnemiesGreatPalace.RED_FOKKA,
+        EnemiesGreatPalace.BLUE_FOKKA,
+        EnemiesGreatPalace.FOKKERU,
+    ];
+    public static readonly EnemiesGreatPalace[] GPGroundEnemies = [.. GPSmallEnemies, .. GPLargeEnemies];
+    public static readonly EnemiesGreatPalace[] GPFlyingEnemies = [
+        EnemiesGreatPalace.ORANGE_MOA,
+        EnemiesGreatPalace.SLOW_BUBBLE,
+        EnemiesGreatPalace.FAST_BUBBLE,
+        EnemiesGreatPalace.BIG_BUBBLE,
+        EnemiesGreatPalace.KING_BOT, // Not actually a flying enemy
+    ];
+    public static readonly EnemiesGreatPalace[] GPGenerators = [
+        EnemiesGreatPalace.BUBBLE_GENERATOR,
+        EnemiesGreatPalace.ROCK_GENERATOR,
+        EnemiesGreatPalace.FIRE_BAGO_BAGO_GENERATOR,
+        EnemiesGreatPalace.ORANGE_DRAGON_HEAD_GENERATOR,
+    ];
+
+
+    public static readonly int[] StandardPalaceGroundEnemies = Palace125GroundEnemies.Select(e => (int)e).Union(Palace346GroundEnemies.Select(e => (int)e)).ToArray();
+    public static readonly int[] StandardPalaceFlyingEnemies = Palace125FlyingEnemies.Select(e => (int)e).Union(Palace346FlyingEnemies.Select(e => (int)e)).ToArray();
+    public static readonly int[] StandardPalaceGenerators = Palace125Generators.Select(e => (int)e).Union(Palace346Generators.Select(e => (int)e)).ToArray();
+    public static readonly int[] StandardPalaceSmallEnemies = Palace125SmallEnemies.Select(e => (int)e).Union(Palace346SmallEnemies.Select(e => (int)e)).ToArray();
+    public static readonly int[] StandardPalaceLargeEnemies = Palace125LargeEnemies.Select(e => (int)e).Union(Palace346LargeEnemies.Select(e => (int)e)).ToArray();
+
 
     //TODO: Turn this into constants and a lookup, then replace the above nonsense with const arrays of constants instead of garbage
     /*
@@ -276,7 +344,7 @@ public enum EnemiesPalace346
     WOLF_HEAD = 0x1C,
     WIZARD = 0x1D,
     DOOMKNOCKER = 0x1E,
-    ARMORED_RED_STALFOS = 0x1F,
+    RED_STALFOS = 0x1F,
     REBONAK = 0x20,
     BARBA = 0x21,
     CAROCK = 0x22,

--- a/RandomizerCore/Hyrule.cs
+++ b/RandomizerCore/Hyrule.cs
@@ -2845,7 +2845,7 @@ public class Hyrule
 
         if (props.ShuffleDripper)
         {
-            ROMData.Put(0x11927, (byte)Enemies.Palace125Enemies[RNG.Next(Enemies.Palace125Enemies.Length)]);
+            ROMData.Put(0x11927, (byte)Enemies.Palace125GroundEnemies[RNG.Next(Enemies.Palace125GroundEnemies.Length)]);
         }
 
         if (props.ShuffleEnemyPalettes)

--- a/RandomizerCore/Sidescroll/EnemiesEditable.cs
+++ b/RandomizerCore/Sidescroll/EnemiesEditable.cs
@@ -129,7 +129,7 @@ public class Enemy<T> where T : Enum
     }
 
     /// <summary>
-    /// Access the enemy number
+    /// Access the enemy ID as its enum representation
     /// </summary>
     public T Id
     {
@@ -137,10 +137,109 @@ public class Enemy<T> where T : Enum
         set { Bytes[1] = (byte)((Bytes[1] & 0b11000000) | (Convert.ToByte(value) & 0b00111111)); }
     }
 
+    /// <summary>
+    /// Access the enemy ID as a byte
+    /// </summary>
+    public byte IdByte
+    {
+        get => (byte)(Bytes[1] & 0b00111111);
+        set { Bytes[1] = (byte)((Bytes[1] & 0b11000000) | (value & 0b00111111)); }
+    }
+
     public String DebugString()
     {
         var bytes = Convert.ToHexString(Bytes);
         var idString = $"Id";
         return $"{bytes,-4}  {X,2},{Y,2}  {idString}";
+    }
+
+    /// <summary>
+    /// Is this a shufflable small enemy? EnemiesPalace125 and EnemiesPalace346 IDs may be mixed.
+    /// </summary>
+    public bool IsShufflableSmall()
+    {
+        switch (this)
+        {
+            case Enemy<EnemiesPalace125>:
+                return Enemies.StandardPalaceSmallEnemies.Contains(IdByte);
+            case Enemy<EnemiesPalace346>:
+                return Enemies.StandardPalaceSmallEnemies.Contains(IdByte);
+            case Enemy<EnemiesGreatPalace>:
+                return Enemies.GPSmallEnemies.Any(e => e.Equals(Id));
+            default:
+                throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    /// Is this a shufflable large enemy? EnemiesPalace125 and EnemiesPalace346 IDs may be mixed.
+    /// </summary>
+    public bool IsShufflableLarge()
+    {
+        switch (this)
+        {
+            case Enemy<EnemiesPalace125>:
+                return Enemies.StandardPalaceLargeEnemies.Contains(IdByte);
+            case Enemy<EnemiesPalace346>:
+                return Enemies.StandardPalaceLargeEnemies.Contains(IdByte);
+            case Enemy<EnemiesGreatPalace>:
+                return Enemies.GPLargeEnemies.Any(e => e.Equals(Id));
+            default:
+                throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    /// Is this a shufflable regular large or small enemy? EnemiesPalace125 and EnemiesPalace346 IDs may be mixed.
+    /// </summary>
+    public bool IsShufflableSmallOrLarge()
+    {
+        switch (this)
+        {
+            case Enemy<EnemiesPalace125>:
+                return Enemies.StandardPalaceGroundEnemies.Contains(IdByte);
+            case Enemy<EnemiesPalace346>:
+                return Enemies.StandardPalaceGroundEnemies.Contains(IdByte);
+            case Enemy<EnemiesGreatPalace>:
+                return Enemies.GPGroundEnemies.Any(e => e.Equals(Id));
+            default:
+                throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    /// Is this a shufflable flying enemy? EnemiesPalace125 and EnemiesPalace346 IDs may be mixed.
+    /// </summary>
+    public bool IsShufflableFlying()
+    {
+        switch (this)
+        {
+            case Enemy<EnemiesPalace125>:
+                return Enemies.StandardPalaceFlyingEnemies.Contains(IdByte);
+            case Enemy<EnemiesPalace346>:
+                return Enemies.StandardPalaceFlyingEnemies.Contains(IdByte);
+            case Enemy<EnemiesGreatPalace>:
+                return Enemies.GPFlyingEnemies.Any(e => e.Equals(Id));
+            default:
+                throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    /// Is this a shufflable enemy generator? EnemiesPalace125 and EnemiesPalace346 IDs may be mixed.
+    /// </summary>
+    public bool IsShufflableGenerator()
+    {
+        switch (this)
+        {
+            case Enemy<EnemiesPalace125>:
+                return Enemies.StandardPalaceGenerators.Contains(IdByte);
+            case Enemy<EnemiesPalace346>:
+                return Enemies.StandardPalaceGenerators.Contains(IdByte);
+            case Enemy<EnemiesGreatPalace>:
+                return Enemies.GPGenerators.Any(e => e.Equals(Id));
+            default:
+                throw new NotImplementedException();
+        }
     }
 }

--- a/RandomizerCore/Sidescroll/Room.cs
+++ b/RandomizerCore/Sidescroll/Room.cs
@@ -371,151 +371,153 @@ public class Room : IJsonOnDeserialized
 
     public void RandomizeEnemies(bool mixEnemies, bool generatorsAlwaysMatch, Random RNG)
     {
-        int[] allEnemies;
-        int[] smallEnemies;
-        int[] largeEnemies;
-        int[] flyingEnemies;
-        int[] generators;
         //Because a 125 room could be shuffled into 346 or vice versa, we have to check if the enemy is that type in either
         //palace group, and if so, shuffle that enemy into a new enemy specifically appropriate to that palace
-        int[] shufflableEnemies;
-        int[] shufflableSmallEnemies;
-        int[] shufflableLargeEnemies;
-        int[] shufflableFlyingEnemies;
-        int[] shufflableGenerators;
         switch (PalaceGroup)
         {
             case PalaceGrouping.Palace125:
-                allEnemies = RandomizerCore.Enemies.Palace125Enemies;
-                smallEnemies = RandomizerCore.Enemies.Palace125SmallEnemies;
-                largeEnemies = RandomizerCore.Enemies.Palace125LargeEnemies;
-                flyingEnemies = RandomizerCore.Enemies.Palace125FlyingEnemies;
-                generators = RandomizerCore.Enemies.Palace125Generators;
-                shufflableEnemies = RandomizerCore.Enemies.StandardPalaceEnemies;
-                shufflableSmallEnemies = RandomizerCore.Enemies.StandardPalaceSmallEnemies;
-                shufflableLargeEnemies = RandomizerCore.Enemies.StandardPalaceLargeEnemies;
-                shufflableFlyingEnemies = RandomizerCore.Enemies.StandardPalaceFlyingEnemies;
-                shufflableGenerators = RandomizerCore.Enemies.StandardPalaceGenerators;
-                break;
+                {
+                    var allEnemies = RandomizerCore.Enemies.Palace125GroundEnemies;
+                    var smallEnemies = RandomizerCore.Enemies.Palace125SmallEnemies;
+                    var largeEnemies = RandomizerCore.Enemies.Palace125LargeEnemies;
+                    var flyingEnemies = RandomizerCore.Enemies.Palace125FlyingEnemies;
+                    var generators = RandomizerCore.Enemies.Palace125Generators;
+                    var ee = new EnemiesEditable<EnemiesPalace125>(Enemies);
+                    RandomizeEnemiesInner(ee, mixEnemies, generatorsAlwaysMatch, RNG, allEnemies, smallEnemies, largeEnemies, flyingEnemies, generators);
+                    break;
+                }
             case PalaceGrouping.Palace346:
-                allEnemies = RandomizerCore.Enemies.Palace346Enemies;
-                smallEnemies = RandomizerCore.Enemies.Palace346SmallEnemies;
-                largeEnemies = RandomizerCore.Enemies.Palace346LargeEnemies;
-                flyingEnemies = RandomizerCore.Enemies.Palace346FlyingEnemies;
-                generators = RandomizerCore.Enemies.Palace346Generators;
-                shufflableEnemies = RandomizerCore.Enemies.StandardPalaceEnemies;
-                shufflableSmallEnemies = RandomizerCore.Enemies.StandardPalaceSmallEnemies;
-                shufflableLargeEnemies = RandomizerCore.Enemies.StandardPalaceLargeEnemies;
-                shufflableFlyingEnemies = RandomizerCore.Enemies.StandardPalaceFlyingEnemies;
-                shufflableGenerators = RandomizerCore.Enemies.StandardPalaceGenerators;
-                break;
+                {
+                    var allEnemies = RandomizerCore.Enemies.Palace346GroundEnemies;
+                    var smallEnemies = RandomizerCore.Enemies.Palace346SmallEnemies;
+                    var largeEnemies = RandomizerCore.Enemies.Palace346LargeEnemies;
+                    var flyingEnemies = RandomizerCore.Enemies.Palace346FlyingEnemies;
+                    var generators = RandomizerCore.Enemies.Palace346Generators;
+                    var ee = new EnemiesEditable<EnemiesPalace346>(Enemies);
+                    RandomizeEnemiesInner(ee, mixEnemies, generatorsAlwaysMatch, RNG, allEnemies, smallEnemies, largeEnemies, flyingEnemies, generators);
+                    break;
+                }
             case PalaceGrouping.PalaceGp:
-                allEnemies = RandomizerCore.Enemies.GPEnemies;
-                smallEnemies = RandomizerCore.Enemies.GPSmallEnemies;
-                largeEnemies = RandomizerCore.Enemies.GPLargeEnemies;
-                flyingEnemies = RandomizerCore.Enemies.GPFlyingEnemies;
-                generators = RandomizerCore.Enemies.GPGenerators;
-                shufflableEnemies = RandomizerCore.Enemies.GPEnemies;
-                shufflableSmallEnemies = RandomizerCore.Enemies.GPSmallEnemies;
-                shufflableLargeEnemies = RandomizerCore.Enemies.GPLargeEnemies;
-                shufflableFlyingEnemies = RandomizerCore.Enemies.GPFlyingEnemies;
-                shufflableGenerators = RandomizerCore.Enemies.GPGenerators;
-                break;
+                {
+                    var allEnemies = RandomizerCore.Enemies.GPGroundEnemies;
+                    var smallEnemies = RandomizerCore.Enemies.GPSmallEnemies;
+                    var largeEnemies = RandomizerCore.Enemies.GPLargeEnemies;
+                    var flyingEnemies = RandomizerCore.Enemies.GPFlyingEnemies;
+                    var generators = RandomizerCore.Enemies.GPGenerators;
+                    var ee = new EnemiesEditable<EnemiesGreatPalace>(Enemies);
+                    RandomizeEnemiesInner(ee, mixEnemies, generatorsAlwaysMatch, RNG, allEnemies, smallEnemies, largeEnemies, flyingEnemies, generators);
+                    break;
+                }
             default:
                 throw new ImpossibleException("Invalid Palace Group");
         }
+    }
+
+    private void RandomizeEnemiesInner<T>(EnemiesEditable<T> ee, bool mixEnemies, bool generatorsAlwaysMatch, Random RNG, T[] allEnemies, T[] smallEnemies, T[] largeEnemies, T[] flyingEnemies, T[] generators) where T : Enum
+    {
+        T RerollLargeEnemyIfNeeded(Enemy<T> enemy, T swapToId)
+        {
+            if (PalaceGroup != PalaceGrouping.PalaceGp)
+            {
+                while (true)
+                {
+                    switch (swapToId)
+                    {
+                        case EnemiesPalace125.MAGO:
+                        case EnemiesPalace346.WIZARD:
+                            // Re-roll Magos and Wizards unless their y pos is 7.
+                            if (enemy.Y != 0x07)
+                            {
+                                swapToId = largeEnemies[RNG.Next(0, largeEnemies.Length)];
+                                continue;
+                            }
+                            break;
+                    }
+                    break;
+                }
+            }
+            return swapToId;
+        }
+
+        T RerollFlyingEnemyIfNeeded(Enemy<T> enemy, T swapToId)
+        {
+            if (PalaceGroup != PalaceGrouping.PalaceGp)
+            {
+                // The rando does not re-roll Moas in regular palaces (I just simplified the legacy behavior)
+                if (enemy.IdByte == EnemiesRegularPalaceShared.ORANGE_MOA)
+                {
+                    swapToId = enemy.Id; // swap it back to Moa
+                }
+            }
+            return swapToId;
+        }
 
         int? firstGenerator = null;
-        var enemiesLength = (int)Enemies[0] - 1;
-        NewEnemies[0] = Enemies[0];
-        for (int i = 1; i <= enemiesLength; i += 2)
+        for (int i = 0; i < ee.Enemies.Count; i++)
         {
-            NewEnemies[i] = Enemies[i];
-            var enemyNumber = Enemies[i + 1] & 0x3F;
-            var enemyPage = Enemies[i + 1] & 0xC0;
-            if (mixEnemies)
+            Enemy<T> enemy = ee.Enemies[i];
+
+            if (mixEnemies) // mix small and large enemies
             {
                 //If this is a shufflable enemy (As opposed to something like a crystal marker)
-                if (shufflableEnemies.Contains(enemyNumber))
+                if (enemy.IsShufflableSmallOrLarge())
                 {
-                    var swapEnemy = allEnemies[RNG.Next(0, allEnemies.Length)];
-                    var ypos = Enemies[i] & 0xF0;
-                    var xpos = Enemies[i] & 0x0F;
-                    if (shufflableSmallEnemies.Contains(enemyNumber) && shufflableLargeEnemies.Contains(swapEnemy))
+                    T swapToId = allEnemies[RNG.Next(0, allEnemies.Length)];
+                    if (enemy.IsShufflableSmall() && largeEnemies.Contains(swapToId))
                     {
-                        ypos -= 16;
-                        while (swapEnemy == 0x1D && ypos != 0x70 && PalaceGroup != PalaceGrouping.PalaceGp)
-                        {
-                            swapEnemy = largeEnemies[RNG.Next(0, largeEnemies.Length)];
-                        }
+                        enemy.Y--; // subtract Y by 1 when switching a small enemy to a large enemy
+                        swapToId = RerollLargeEnemyIfNeeded(enemy, swapToId);
                     }
                     else
                     {
-                        while (swapEnemy == 0x1D && ypos != 0x70 && PalaceGroup != PalaceGrouping.PalaceGp)
-                        {
-                            swapEnemy = allEnemies[RNG.Next(0, allEnemies.Length)];
-                        }
+                        swapToId = RerollLargeEnemyIfNeeded(enemy, swapToId);
                     }
-
-                    NewEnemies[i] = (byte)(ypos + xpos);
-                    NewEnemies[i + 1] = (byte)(enemyPage + swapEnemy);
+                    enemy.Id = swapToId;
                     continue;
                 }
             }
             else
             {
-                if (shufflableLargeEnemies.Contains(enemyNumber))
+                if (enemy.IsShufflableLarge())
                 {
-                    var swap = RNG.Next(0, largeEnemies.Length);
-                    var ypos = Enemies[i] & 0xF0;
-                    var xpos = Enemies[i] & 0x0F;
-                    while (largeEnemies[swap] == 0x1D && ypos != 0x70 && PalaceGroup != PalaceGrouping.PalaceGp)
-                    {
-                        swap = RNG.Next(0, largeEnemies.Length);
-                    }
-                    NewEnemies[i + 1] = (byte)(largeEnemies[swap] + enemyPage);
+                    T swapToId = largeEnemies[RNG.Next(0, largeEnemies.Length)];
+                    swapToId = RerollLargeEnemyIfNeeded(enemy, swapToId);
+                    enemy.Id = swapToId;
                     continue;
                 }
-                else if (shufflableSmallEnemies.Contains(enemyNumber))
+                else if (enemy.IsShufflableSmall())
                 {
-                    int swap = RNG.Next(0, smallEnemies.Length);
-                    NewEnemies[i + 1] = (byte)(smallEnemies[swap] + enemyPage);
+                    T swapEnemy = smallEnemies[RNG.Next(0, smallEnemies.Length)];
+                    enemy.Id = swapEnemy;
                     continue;
                 }
             }
 
-
-            if (shufflableFlyingEnemies.Contains(enemyNumber))
+            if (enemy.IsShufflableFlying())
             {
-                var swap = RNG.Next(0, flyingEnemies.Length);
-                while (enemyNumber == 0x07 && (flyingEnemies[swap] == 0x06 || flyingEnemies[swap] == 0x0E))
-                {
-                    swap = RNG.Next(0, flyingEnemies.Length);
-                }
-                NewEnemies[i + 1] = (byte)(flyingEnemies[swap] + enemyPage);
+                T swapToId = flyingEnemies[RNG.Next(0, flyingEnemies.Length)];
+                swapToId = RerollFlyingEnemyIfNeeded(enemy, swapToId);
+                enemy.Id = swapToId;
                 continue;
             }
 
-            if (shufflableGenerators.Contains(enemyNumber))
+            if (enemy.IsShufflableGenerator())
             {
-                var swap = RNG.Next(0, generators.Length);
-                firstGenerator ??= swap;
+                T swapToId = generators[RNG.Next(0, generators.Length)];
+                firstGenerator ??= (int)(object)swapToId;
                 if (generatorsAlwaysMatch)
                 {
-                    NewEnemies[i + 1] = (byte)(generators[firstGenerator ?? 0] + enemyPage);
+                    enemy.Id = (T)(object)firstGenerator;
                     continue;
                 }
                 else
                 {
-                    NewEnemies[i + 1] = (byte)(generators[swap] + enemyPage);
+                    enemy.Id = swapToId;
                     continue;
                 }
             }
-
-            //If this is not a shufflable enemy, just copy it as is.
-            NewEnemies[i] = Enemies[i];
-            NewEnemies[i + 1] = Enemies[i + 1];
         }
+        NewEnemies = ee.Finalize();
     }
 
     public void AdjustContinuingBossRoom()

--- a/RandomizerCore/Sidescroll/SideviewEditable.cs
+++ b/RandomizerCore/Sidescroll/SideviewEditable.cs
@@ -241,4 +241,18 @@ public class SideviewEditable<T> where T : Enum
         }
         return result;
     }
+
+    public static bool AreaIsOpen(bool[,] solidGrid, int x1, int x2, int y1, int y2)
+    {
+        for (int x = x1; x <= x2; x++)
+        {
+            if (x >= solidGrid.GetLength(0)) { return false; }
+            for (int y = y1; y <= y2; y++)
+            {
+                if (y >= solidGrid.GetLength(1)) { return false; }
+                if (solidGrid[x, y]) { return false; }
+            }
+        }
+        return true;
+    }
 }


### PR DESCRIPTION
[Refactor RandomizeEnemies to use EnemiesEditable and the new enemy enums](https://github.com/Ellendar/Z2Randomizer/commit/9674e6d9c3778ba18431089bc9f23cf8cd20878d) 

- Renamed Palace125Enemies, Palace346Enemies, and GPEnemies to *GroundEnemies to prevent confusion (they do not include ALL enemies)
- Palace*Enemies arrays now uses enums
- StandardPalace*Enemies arrays still uses ints since they span two different enums
- GP*Enemies arrays uses enums only

[Modify RandomizeEnemies to utilize a solid grid for better randomization](https://github.com/Ellendar/Z2Randomizer/commit/49a493a29b75a950f07f31bb57c7c0ddd5fe61b9) 

- No longer roll Stalfos where they will get stuck (basically low ceilings)
- Make sure King Bots only roll where they have room (in 3x2 open tiles - so not in Waffle rooms)