### PR TITLE
Fix AllowForChangingElevatorYPosition for Death Mountain elevators

### DIFF
--- a/RandomizerCore/ROM.cs
+++ b/RandomizerCore/ROM.cs
@@ -1157,6 +1157,19 @@ LoadDoorYPosition:
         a.Module().Code("""
 .include "z2r.inc"
 
+.segment "PRG1"
+.org $82BA ; death mountain
+    jsr StoreElevatorParamDM
+
+.segment "PRG1", "PRG7"
+.reloc
+StoreElevatorParamDM:
+    lda $0731 ; load the current elevator command
+    and #$0f ; the last 4 bits are the param
+    sta ElevatorYStart
+    lda $010A ; re-do the command JSR overwrote
+    rts
+
 .segment "PRG4"
 .org $823E ; palace 1-6
     jsr StoreElevatorParam


### PR DESCRIPTION
If you went into a palace before DM, DM would use the elevator param from your last palace room. Now it loads its own param (they are all 0).