### PR TITLE
Refactoring and changing the way level up works when level cap is less than 8

### DIFF
--- a/RandomizerCore/Hyrule.cs
+++ b/RandomizerCore/Hyrule.cs
@@ -2668,6 +2668,8 @@ public class Hyrule
 
         rom.SetLevelCap(a, props.AttackCap, props.MagicCap, props.LifeCap);
 
+        rom.ChangeLevelUpCancelling(a);
+
         RandomizeAttackEffectiveness(rom, props.AttackEffectiveness);
 
         RandomizeLifeEffectiveness(rom);

--- a/RandomizerCore/Hyrule.cs
+++ b/RandomizerCore/Hyrule.cs
@@ -2641,7 +2641,7 @@ public class Hyrule
 
         RandomizeExperience(rom);
 
-        rom.SetLevelCap(props.AttackCap, props.MagicCap, props.LifeCap);
+        rom.SetLevelCap(a, props.AttackCap, props.MagicCap, props.LifeCap);
 
         RandomizeAttackEffectiveness(rom, props.AttackEffectiveness);
 

--- a/RandomizerCore/Hyrule.cs
+++ b/RandomizerCore/Hyrule.cs
@@ -2206,7 +2206,32 @@ public class Hyrule
                 }
             }
 
-            return cappedExp;
+            randomized = cappedExp;
+        }
+
+        // Make sure all 1-up levels are higher cost than regular levels
+        int highestRegularLevelExp = 0;
+        for (int stat = 0; stat < 3; stat++)
+        {
+            var cap = levelCap[stat];
+            if (cap < 2) { continue; }
+            var statStartIndex = stat * 8;
+            int statMaxLevelIndex = statStartIndex + cap - 2;
+            var maxExp = randomized[statMaxLevelIndex];
+            if (highestRegularLevelExp < maxExp) { highestRegularLevelExp = maxExp; }
+        }
+
+        int min1upExp = Math.Min(highestRegularLevelExp + 10, 9990);
+        for (int stat = 0; stat < 3; stat++)
+        {
+            var cap = levelCap[stat];
+            Debug.Assert(cap >= 1);
+            var statStartIndex = stat * 8;
+            int stat1upLevelIndex = statStartIndex + cap - 1;
+            var exp1up = randomized[stat1upLevelIndex];
+            if (exp1up < min1upExp) {
+                randomized[stat1upLevelIndex] = RNG.Next(min1upExp, 9990) / 10 * 10;
+            }
         }
 
         return randomized;

--- a/RandomizerCore/ROM.cs
+++ b/RandomizerCore/ROM.cs
@@ -816,39 +816,28 @@ TitleEnd:
         Put(0x1a975, 0);
     }
 
-    public void SetLevelCap(int atkMax, int magicMax, int lifeMax)
+    public void SetLevelCap(Assembler asm, int atkMax, int magicMax, int lifeMax)
     {
+        var a = asm.Module();
+        a.Code("""
+.segment "PRG0"
+.org $9F7A
+    jmp LoadNewLevelCap
+    nop
+    nop
+LoadNewLevelCapReturn:        ; $9F7F
 
-        //jump to check which attribute is levelling up
-        Put(0x1f8a, 0x4C);
-        Put(0x1f8b, 0x9e);
-        Put(0x1f8c, 0xa8);
-
-        ////x = 2 life, x = 1 magic, x = 0 attack
-        //load current level for (attack, magic, life)
-        //compare to address of cap
-        //go back to $9f7f
-
-        //BD 77 07 (load level)
-        //DD A7 A8
-        //4C 7F 9F
-
-        Put(0x28AE, 0xBD);
-        Put(0x28AF, 0x77);
-        Put(0x28B0, 0x07);
-        Put(0x28B1, 0xDD);
-        Put(0x28B2, 0xA7);
-        Put(0x28B3, 0xA8);
-        Put(0x28B4, 0x4C);
-        Put(0x28B5, 0x7F);
-        Put(0x28B6, 0x9F);
-
-        //these are the actual caps
-        Put(0x28B7, (byte)atkMax);
-        Put(0x28B8, (byte)magicMax);
-        Put(0x28B9, (byte)lifeMax);
-
-
+.org $A89E
+LoadNewLevelCap:
+    lda $0777,X               ; the instruction we overwrote with jmp
+    cmp LevelCaps,X
+    jmp LoadNewLevelCapReturn
+""");
+        a.Org(0xa8a7);
+        a.Label("LevelCaps");
+        a.Byt((byte)atkMax);
+        a.Byt((byte)magicMax);
+        a.Byt((byte)lifeMax);
     }
 
     public void UseExtendedBanksForPalaceRooms(Assembler a)

--- a/RandomizerCore/ROM.cs
+++ b/RandomizerCore/ROM.cs
@@ -222,6 +222,11 @@ Color.FromArgb(236, 238, 236), Color.FromArgb(168, 204, 236), Color.FromArgb(188
         return bytes;
     }
 
+    public int GetShort(int indexMsb, int indexLsb)
+    {
+        return (GetByte(indexMsb) << 8) + GetByte(indexLsb);
+    }
+
     public void Put(int index, byte data)
     {
         rawdata[index] = data;
@@ -238,6 +243,12 @@ Color.FromArgb(236, 238, 236), Color.FromArgb(168, 204, 236), Color.FromArgb(188
         {
             rawdata[index + i] = data[i];
         }
+    }
+
+    public void PutShort(int indexMsb, int indexLsb, int data)
+    {
+        Put(indexMsb, (byte)(data / 256));
+        Put(indexLsb, (byte)(data % 256));
     }
 
     public void Dump(string filename)


### PR DESCRIPTION
First, refactoring, then the following changes:

[Never randomize experience for 1ups lower than regular levels](https://github.com/Ellendar/Z2Randomizer/commit/6099e98c76dd22f4624c01c8ac55d7bbd575726f)
This solves the annoyance of level capping a stat, and having the 1-up level ups for that stat get in the way of maximizing crystal exp for the other stats. I think it's also a change that is wanted for regular stat-uncapped seeds.

This, however, introduces another problem that also had to be solved. The problem being that it gets easier to get a lot of crystal exp from capping one stat at a low level and maxing it out early, effectively making the game easier. Capping a stat level should still make the game harder.

(I know this is solved by the Scaling exp option, but that option also drastically changes the level up flow.)

Which led to...

[Change the way level up cancelling works if level cap is less than 8](https://github.com/Ellendar/Z2Randomizer/commit/f6e58c5bdf2d82fcae0d3a17fde46aed9247f008)
If the level cap for a stat is less than 8, we do not allow the player to cancel out of the level up screen to continue chasing the experience for that stat once it is maxed. To stay true to vanilla, this is still allowed if the level cap is 8.