### PR TITLE
Custom sprite IPS sanitization

### DIFF
--- a/CommandLine/DefaultPlayerOptions.json
+++ b/CommandLine/DefaultPlayerOptions.json
@@ -8,6 +8,8 @@
   "RemoveFlashingUponDeath": true,
   "DisableHUDLag": true,
   "Sprite": "Link",
+  "SanitizeSprite": true,
+  "ChangeItemSprites": true,
   "TunicColor": "Default",
   "TunicOutlineColor": "Default",
   "ShieldTunicColor": "Default",

--- a/CommandLine/Models/PlayerOptions.cs
+++ b/CommandLine/Models/PlayerOptions.cs
@@ -22,6 +22,10 @@ namespace Z2Randomizer.CommandLine.Models
 
         public string? Sprite { get; set; }
 
+        public bool SanitizeSprite { get; set; }
+
+        public bool ChangeItemSprites { get; set; }
+
         [JsonConverter(typeof(StringEnumConverter))]
         public CharacterColor TunicColor { get; set; }
 

--- a/CommandLine/PlayerOptionsService.cs
+++ b/CommandLine/PlayerOptionsService.cs
@@ -72,6 +72,8 @@ namespace Z2Randomizer.CommandLine
 
             configuration.RemoveFlashing = playerOptions.RemoveFlashingUponDeath;
             configuration.UpAOnController1 = playerOptions.RemapUpAToUpSelect;
+            configuration.SanitizeSprite = playerOptions.SanitizeSprite;
+            configuration.ChangeItemSprites = playerOptions.ChangeItemSprites;
             configuration.Tunic = playerOptions.TunicColor;
             configuration.TunicOutline = playerOptions.TunicOutlineColor;
             configuration.ShieldTunic = playerOptions.ShieldTunicColor;

--- a/CommandLine/Sample.json
+++ b/CommandLine/Sample.json
@@ -156,6 +156,8 @@
 "StartWithThunder": false,
 "SwapUpAndDownStab": false,
 "TBirdRequired": true,
+"SanitizeSprite": true,
+"ChangeItemSprites": true,
 "Tunic": "Pink",
 "TunicOutline": "Default",
 "UpAOnController1": false,

--- a/CrossPlatformUI/ViewModels/Tabs/SpritePreviewViewModel.cs
+++ b/CrossPlatformUI/ViewModels/Tabs/SpritePreviewViewModel.cs
@@ -29,7 +29,16 @@ public class SpritePreviewViewModel : ReactiveObject, IActivatableViewModel
         get { return spriteName; }
         set { spriteName = value ?? "Link"; Main.Config.SpriteName = value ?? "Link"; }
     }
-
+    public bool SanitizeSprite
+    {
+        get => Main.Config.SanitizeSprite;
+        set { Main.Config.SanitizeSprite = value; this.RaisePropertyChanged(); }
+    }
+    public bool ChangeItemSprites
+    {
+        get => Main.Config.ChangeItemSprites;
+        set { Main.Config.ChangeItemSprites = value; this.RaisePropertyChanged(); }
+    }
     public CharacterColor TunicColor
     {
         get => Main.Config.Tunic;
@@ -180,7 +189,8 @@ public class LoadedCharacterSprite : ReactiveObject
     public async Task Update(CharacterColor tunicColor, CharacterColor outlineColor, CharacterColor shieldColor, BeamSprites beamSprite)
     {
         var tmp = new ROM(rom, true);
-        tmp.UpdateSprites(Sprite, tunicColor, outlineColor, shieldColor, beamSprite);
+        // sanitizing will be slower, we don't need to do it for every sprite in the dropdown
+        tmp.UpdateSprites(Sprite, tunicColor, outlineColor, shieldColor, beamSprite, false, false);
         var data = await LoadPreviewFromRom(tmp);
         unsafe
         {

--- a/CrossPlatformUI/Views/Tabs/SpritePreviewView.axaml
+++ b/CrossPlatformUI/Views/Tabs/SpritePreviewView.axaml
@@ -26,7 +26,9 @@
                     </DataTemplate>
                 </ComboBox.ItemTemplate>
             </ComboBox>
-            <ComboBox assists:ComboBoxAssist.Label="Tunic Color" Theme="{StaticResource MaterialOutlineComboBox}" SelectedIndex="0"
+			<CheckBox IsChecked="{Binding SanitizeSprite}" Content="Moderate Sprite Access to ROM" />
+			<CheckBox IsEnabled="{Binding SanitizeSprite}" IsChecked="{Binding ChangeItemSprites}" Content="Change Item Sprites" />
+			<ComboBox assists:ComboBoxAssist.Label="Tunic Color" Theme="{StaticResource MaterialOutlineComboBox}" SelectedIndex="0"
                       ItemsSource="{Binding Source={x:Static rc:Enums.CharacterColorList}}"
                       SelectedItem="{Binding TunicColor, Converter={x:Static ui:Util.EnumConvert}}" />
 			<ComboBox assists:ComboBoxAssist.Label="Tunic Outline Color" Theme="{StaticResource MaterialOutlineComboBox}" SelectedIndex="0"

--- a/RandomizerCore/Hyrule.cs
+++ b/RandomizerCore/Hyrule.cs
@@ -2340,7 +2340,7 @@ public class Hyrule
         }
 
         rom.Put(ROM.ChrRomOffset + 0x1a000, Util.ReadBinaryResource("Z2Randomizer.RandomizerCore.Asm.Graphics.item_sprites.chr"));
-        rom.UpdateSprites(props.CharSprite, props.TunicColor, props.OutlineColor, props.ShieldColor, props.BeamSprite);
+        rom.UpdateSprites(props.CharSprite, props.TunicColor, props.OutlineColor, props.ShieldColor, props.BeamSprite, props.SanitizeSprite, props.ChangeItemSprites);
         rom.Put(ROM.ChrRomOffset + 0x01000, Util.ReadBinaryResource("Z2Randomizer.RandomizerCore.Asm.Graphics.randomizer_text.chr"));
 
         if (props.EncounterRates == EncounterRate.NONE)

--- a/RandomizerCore/ROM.cs
+++ b/RandomizerCore/ROM.cs
@@ -156,6 +156,14 @@ Color.FromArgb(236, 238, 236), Color.FromArgb( 76, 154, 236), Color.FromArgb(120
 Color.FromArgb(236, 238, 236), Color.FromArgb(168, 204, 236), Color.FromArgb(188, 188, 236), Color.FromArgb(212, 178, 236), Color.FromArgb(236, 174, 236), Color.FromArgb(236, 174, 212), Color.FromArgb(236, 180, 176), Color.FromArgb(228, 196, 144), Color.FromArgb(204, 210, 120), Color.FromArgb(180, 222, 120), Color.FromArgb(168, 226, 144), Color.FromArgb(152, 226, 180), Color.FromArgb(160, 214, 228), Color.FromArgb(160, 162, 160), Color.FromArgb(  0,   0,   0), Color.FromArgb(  0,   0,   0),
     };
 
+    public static readonly int[] LinkOutlinePaletteAddr = {         0x285a, 0x2a0a, 0x40af, 0x40bf, 0x40cf, 0x40df, 0x80af, 0x80bf, 0x80cf, 0x80df, 0xc0af, 0xc0bf, 0xc0cf, 0xc0df, 0xc0ef, 0x100af, 0x100bf, 0x100cf, 0x100df, 0x140af, 0x140bf, 0x140cf, 0x140df, 0x17c19, 0x1c464, 0x1c47c };
+    public static readonly int[] LinkFacePaletteAddr =    {         0x285b, 0x2a10, 0x40b0, 0x40c0, 0x40d0, 0x40e0, 0x80b0, 0x80c0, 0x80d0, 0x80e0, 0xc0b0, 0xc0c0, 0xc0d0, 0xc0e0, 0xc0f0, 0x100b0, 0x100c0, 0x100d0, 0x100e0, 0x140b0, 0x140c0, 0x140d0, 0x140e0, 0x17c1a, 0x1c465, 0x1c47d };
+    public static readonly int[] LinkTunicPaletteAddr =   { 0x10ea, 0x285c, 0x2a16, 0x40b1, 0x40c1, 0x40d1, 0x40e1, 0x80b1, 0x80c1, 0x80d1, 0x80e1, 0xc0b1, 0xc0c1, 0xc0d1, 0xc0e1, 0xc0f1, 0x100b1, 0x100c1, 0x100d1, 0x100e1, 0x140b1, 0x140c1, 0x140d1, 0x140e1, 0x17c1b, 0x1c466, 0x1c47e };
+    public const int LinkShieldPaletteAddr = 0xe9e;
+    public static readonly int[] ZeldaOutlinePaletteAddr = { 0x4025, 0x8025, 0x14049, 0x140c7 };
+    public static readonly int[] ZeldaFacePaletteAddr =    { 0x4023, 0x8023, 0x14047, 0x140c9 };
+    public static readonly int[] ZeldaDressPaletteAddr =   { 0x4024, 0x8024, 0x14048, 0x140c8 };
+
 
     public byte[] rawdata { get; }
 
@@ -648,27 +656,23 @@ TitleEnd:
             }
         }
 
-        int[] tunicLocs = { 0x10ea, 0x285C, 0x40b1, 0x40c1, 0x40d1, 0x80e1, 0x80b1, 0x80c1, 0x80d1, 0x80e1, 0xc0b1, 0xc0c1, 0xc0d1, 0xc0e1, 0x100b1, 0x100c1, 0x100d1, 0x100e1, 0x140b1, 0x140c1, 0x140d1, 0x140e1, 0x17c1b, 0x1c466, 0x1c47e };
-        int[] outlineLocs = { 0x285a, 0x2a0a, 0x40af, 0x40bf, 0x40cf, 0x40df, 0x80af, 0x80bf, 0x80cf, 0x80df, 0xc0af, 0xc0bf, 0xc0cf, 0xc0df, 0xc0ef, 0x100af, 0x100bf, 0x100cf, 0x100df, 0x140af, 0x140bf, 0x140cf, 0x140df, 0x17c19, 0x1c464, 0x1c47c };
-        int shieldLoc = 0xe9e;
-
         if(tunicColor != CharacterColor.Default && tunicColorInt != null)
         { 
-            foreach(int l in tunicLocs)
+            foreach(int l in LinkTunicPaletteAddr)
             {
                 Put(l, (byte)tunicColorInt);
             }
         }
         if(outlineColor != CharacterColor.Default && outlineColorInt != null)
         {
-            foreach(int l in outlineLocs)
+            foreach(int l in LinkOutlinePaletteAddr)
             {
                 Put(l, (byte)outlineColorInt);
             }
         }
         if(shieldColor != CharacterColor.Default && shieldColorInt != null)
         {
-            Put(shieldLoc, (byte)shieldColorInt);
+            Put(LinkShieldPaletteAddr, (byte)shieldColorInt);
         }
 
         if(beamSprite == BeamSprites.RANDOM)

--- a/RandomizerCore/ROM.cs
+++ b/RandomizerCore/ROM.cs
@@ -549,7 +549,7 @@ TitleEnd:
         ChrRomOffset + 0x18840 
     };
 
-    public void UpdateSprites(CharacterSprite charSprite, CharacterColor tunicColor, CharacterColor outlineColor, CharacterColor shieldColor, BeamSprites beamSprite)
+    public void UpdateSprites(CharacterSprite charSprite, CharacterColor tunicColor, CharacterColor outlineColor, CharacterColor shieldColor, BeamSprites beamSprite, bool sanitize, bool changeItems)
     {
         /*
          * Dear future digshake,
@@ -575,7 +575,14 @@ TitleEnd:
          */
 
         if (charSprite.Patch != null) {
-            IpsPatcher.Patch(rawdata, charSprite.Patch, true);
+            if (sanitize)
+            {
+                SpritePatcher.PatchSpriteSanitized(rawdata, charSprite.Patch, true, changeItems);
+            }
+            else
+            {
+                IpsPatcher.Patch(rawdata, charSprite.Patch, true);
+            }
         }
 
         var colorMap = new Dictionary<CharacterColor, int>()

--- a/RandomizerCore/RandomizerConfiguration.cs
+++ b/RandomizerCore/RandomizerConfiguration.cs
@@ -182,6 +182,8 @@ public sealed class RandomizerConfiguration : INotifyPropertyChanged
     private bool removeFlashing;
     private CharacterSprite sprite;
     private string spriteName;
+    private bool sanitizeSprite;
+    private bool changeItemSprites;
     private CharacterColor tunic;
     private CharacterColor tunicOutline;
     private CharacterColor shieldTunic;
@@ -995,6 +997,20 @@ public sealed class RandomizerConfiguration : INotifyPropertyChanged
     }
 
     [IgnoreInFlags]
+    public bool SanitizeSprite
+    {
+        get => sanitizeSprite;
+        set => SetField(ref sanitizeSprite, value);
+    }
+
+    [IgnoreInFlags]
+    public bool ChangeItemSprites
+    {
+        get => changeItemSprites;
+        set => SetField(ref changeItemSprites, value);
+    }
+
+    [IgnoreInFlags]
     public CharacterColor Tunic
     {
         get => tunic;
@@ -1796,6 +1812,8 @@ public sealed class RandomizerConfiguration : INotifyPropertyChanged
         properties.MixCustomAndOriginalMusic = MixCustomAndOriginalMusic;
         properties.DisableUnsafeMusic = DisableUnsafeMusic;
         properties.CharSprite = Sprite;
+        properties.SanitizeSprite = SanitizeSprite;
+        properties.ChangeItemSprites = ChangeItemSprites;
         properties.TunicColor = Tunic;
         properties.OutlineColor = TunicOutline;
         properties.ShieldColor = ShieldTunic;

--- a/RandomizerCore/RandomizerProperties.cs
+++ b/RandomizerCore/RandomizerProperties.cs
@@ -204,6 +204,8 @@ public class RandomizerProperties
 #pragma warning disable CS8618 
     public CharacterSprite CharSprite { get; set; }
 #pragma warning restore CS8618
+    public bool SanitizeSprite { get; set; }
+    public bool ChangeItemSprites { get; set; }
     public CharacterColor TunicColor { get; set; }
     public CharacterColor OutlineColor { get; set; }
     public CharacterColor ShieldColor { get; set; }

--- a/RandomizerCore/SpritePatcher.cs
+++ b/RandomizerCore/SpritePatcher.cs
@@ -1,0 +1,298 @@
+﻿using SD.Tools.BCLExtensions.CollectionsRelated;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Z2Randomizer.RandomizerCore;
+
+internal class AddressRange
+{
+    public int Start { get; set; }
+    public int Length { get; set; }
+
+    public AddressRange(int start, int length)
+    {
+        Start = start;
+        Length = length;
+    }
+
+    public static HashSet<int> CreateSet(AddressRange[] ranges) => [.. ranges.SelectMany(r => Enumerable.Range(r.Start, r.Length))];
+
+    public static AddressRange[] ChrRanges(int start, int end, int[] pages)
+    {
+        var length = end - start;
+        return pages.Select(page =>
+        {
+            int romAddrStart = ROM.VanillaChrRomOffs + page * 0x1000 + (start % 0x2000);
+            return new AddressRange(romAddrStart, length);
+        }).ToArray();
+    }
+}
+
+/// <summary>
+/// Applies sanitized IPS sprite patches
+/// </summary>
+internal class SpritePatcher
+{
+    static readonly IReadOnlyList<byte> PatchSig = Encoding.ASCII.GetBytes("PATCH");
+    static readonly IReadOnlyList<byte> EofSig = Encoding.ASCII.GetBytes("EOF");
+
+    public static readonly HashSet<int> ChrItemAddresses = AddressRange.CreateSet([
+        .. AddressRange.ChrRanges(0x0660, 0x0680, [0,0x2,0x4,0x6,0x8,0xA,0xC,0xE,0x10,0x12,0x14,0x16,0x18]), // Key sprite
+        .. AddressRange.ChrRanges(0x0720, 0x0740, [0,0x2,0x4,0x6,0x8,0xA,0xC,0xE,0x10,0x12,0x14,0x16,0x18]), // P-bag sprite
+        .. AddressRange.ChrRanges(0x08a0, 0x09c0, [0,0x2,0x4,0x6,0x8,0xA,0xC,0xE,0x10,0x12,0x14,0x16,0x18]), // Most pickup items
+        .. AddressRange.ChrRanges(0x1800, 0x1840, [0,0x2,0x4,0x6,0x8,0xA,0xC,0xE,0x10,0x12,0x14,0x16,0x18]), // Heart, Magic container
+    ]);
+
+    public static void PatchSpriteSanitized(byte[] romData, byte[] ipsData, bool expandRom, bool changeItems)
+    {
+        Debug.Assert(PatchSig.SequenceEqual(new ArraySegment<byte>(ipsData, 0, PatchSig.Count)));
+
+        int ipsOffs = PatchSig.Count;
+        while (!EofSig.SequenceEqual(new ArraySegment<byte>(ipsData, ipsOffs, EofSig.Count)))
+        {
+            int tgtOffs = ((int)ipsData[ipsOffs] << 16)
+                | ((int)ipsData[ipsOffs + 1] << 8)
+                | ipsData[ipsOffs + 2];
+            ipsOffs += 3;
+
+            int size = ((int)ipsData[ipsOffs] << 8) | ipsData[ipsOffs + 1];
+            ipsOffs += 2;
+
+            byte? fillValue = null;
+            if (size == 0)
+            {
+                size = ((int)ipsData[ipsOffs] << 8) | ipsData[ipsOffs + 1];
+                ipsOffs += 2;
+
+                fillValue = ipsData[ipsOffs++];
+            }
+
+            int srcOffs = tgtOffs;
+            if (expandRom && tgtOffs + size > ROM.VanillaChrRomOffs)
+            {
+                if (tgtOffs < ROM.VanillaChrRomOffs)
+                {
+                    int segSize = ROM.VanillaChrRomOffs - tgtOffs;
+
+                    for (int i = 0; i < segSize; i++)
+                    {
+                        if (IsSanitizedSpriteAddress(srcOffs + i, changeItems))
+                        {
+                            if (fillValue is not null)
+                            {
+                                romData[tgtOffs + i] = (byte)fillValue;
+                            }
+                            else
+                            {
+                                romData[tgtOffs + i] = ipsData[ipsOffs + i];
+                            }
+                        }
+                    }
+                    if (fillValue is null)
+                    {
+                        ipsOffs += segSize;
+                    }
+
+                    tgtOffs += segSize;
+                    srcOffs += segSize;
+                    size -= segSize;
+                }
+
+                tgtOffs += ROM.ChrRomOffset - ROM.VanillaChrRomOffs;
+            }
+
+            for (int i = 0; i < size; i++)
+            {
+                if (IsSanitizedSpriteAddress(srcOffs + i, changeItems))
+                {
+                    if (fillValue is not null)
+                    {
+                        romData[tgtOffs + i] = (byte)fillValue;
+                    }
+                    else
+                    {
+                        romData[tgtOffs + i] = ipsData[ipsOffs + i];
+                    }
+                }
+            }
+            if (fillValue is null)
+            {
+                ipsOffs += size;
+            }
+        }
+    }
+
+    private static bool IsSanitizedSpriteAddress(int addr, bool changeItems)
+    {
+        // NOTE: this isn't written in stone, if anything
+        // more should be allowed, let us know.
+
+        if (ROM.VanillaChrRomOffs <= addr) {
+            if (!changeItems)
+            {
+                if (ChrItemAddresses.Contains(addr))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        // Link's palettes
+        if (ROM.LinkOutlinePaletteAddr.Contains(addr)) { return true; }
+        if (ROM.LinkFacePaletteAddr.Contains(addr)) { return true; }
+        if (ROM.LinkTunicPaletteAddr.Contains(addr)) { return true; }
+        if (ROM.LinkShieldPaletteAddr == addr) { return true; }
+        // Zelda's palettes
+        if (ROM.ZeldaOutlinePaletteAddr.Contains(addr)) { return true; }
+        if (ROM.ZeldaFacePaletteAddr.Contains(addr)) { return true; }
+        if (ROM.ZeldaDressPaletteAddr.Contains(addr)) { return true; }
+        // iNES header
+        if (addr < 0x10) { return false; }
+        // PPU addr before Game over
+        if (0x10 <= addr && addr < 0x12) { return true; }
+        // Not allowing change of length of the text
+        if (0x12 == addr) { return false; }
+        // text: Game over
+        if (0x13 <= addr && addr < 0x13 + 0x0a) { return true; }
+        // PPU addr before Return of Ganon
+        if (0x1d <= addr && addr < 0x1f) { return true; }
+        // Not allowing change of length of the text
+        if (0x1f == addr) { return false; }
+        // text: Return of Ganon
+        if (0x20 <= addr && addr < 0x20 + 0x0f) { return true; }
+        // Palette Mappings
+        if (0x2f <= addr && addr < 0xE5) { return true; }
+
+        // Beam sword projectile
+        // LDA      #$32                      ; 0x18fa  A9 32
+        // STA      ,y                        ; 0x18fc  99 01 02  --  writes to RAM 0x239
+        if (addr == 0x18FB) { return true; }
+        // Level up pane
+        if (0x1bba <= addr && addr < 0x1c2a) { return true; }
+
+        // Table_for_Links_Palettes_Probably
+        if (0x2a00 <= addr && addr < 0x2a18) { return true; }
+
+        // bank1_Pointer_table_for_Background_Areas_Data
+        if (0x4010 <= addr && addr < 0x401e) { return false; }
+        // Palettes_for_Overworld
+        if (0x401e <= addr && addr < 0x40fe) { return true; }
+
+        // bank1_Area_Pointers_West_Hyrule
+        if (0x4533 <= addr && addr < 0x45b1) { return false; }
+        // bank1_Area_Data__West_Hyrule_Random_Battle___Desert__South_West_Hyrule_
+        if (0x478f <= addr && addr < 0x479f) { return false; }
+        // bank1_Background_Areas_Data
+        if (0x4c4c <= addr && addr < 0x506c) { return false; }
+
+        // bank1_Area_Pointers_Death_Mountain
+        if (0x6010 <= addr && addr < 0x610c) { return false; }
+        // Area_Data_Death_Mountain_And_Maze
+        if (0x627c <= addr && addr < 0x665c) { return false; }
+        // Blank data
+        if (0x6943 <= addr && addr < 0x7f80) { return true; }
+
+        // bank2_Pointer_table_for_background_level_data
+        if (0x8010 <= addr && addr < 0x801e) { return false; }
+        // Palettes_for_Overworld
+        if (0x801e <= addr && addr < 0x80fe) { return true; }
+        // bank2_Background_Areas_Data
+        if (0x8c72 <= addr && addr < 0x8ce8) { return false; }
+
+        // bank2_Area_Pointers_Maze_Island
+        if (0xA010 <= addr && addr < 0xA10c) { return false; }
+        // bank2: Area_Data_Death_Mountain_And_Maze
+        if (0xA27c <= addr && addr < 0xA65c) { return false; }
+        // Blank data
+        if (0xA943 <= addr && addr < 0xBf80) { return true; }
+
+        // Palettes for towns
+        if (0xC01e <= addr && addr < 0xC0fe) { return true; }
+        // Area objects tile mappings
+        if (0xC3da <= addr && addr < 0xC51c) { return true; }
+        // bank3_Area_Pointers__Towns
+        if (0xC533 <= addr && addr < 0xC5b1) { return false; }
+        // bank3_Area_Data_Towns1
+        if (0xC9d0 <= addr && addr < 0xCb9e) { return false; }
+        // bank3_SmallObjectsConstructionRoutines_Locked_Door_glitched_tiles_0E
+        if (0xCb9e <= addr && addr < 0xCba5) { return false; }
+        // bank3_Objects_Construction_Routines_Bushes_1_high_X_wide_Y_Position_A__1x
+        if (0xCb9e <= addr && addr < 0xCba5) { return false; }
+        // bank3_Object_Construction_Routine
+        if (0xCba5 <= addr && addr < 0xCbc1) { return false; }
+        // Blank data
+        if (0xCbc1 <= addr && addr < 0xD100) { return true; }
+
+        // bank3_Pointer_table_for_Objects_Construction_Routines
+        if (0xDbaf <= addr && addr < 0xDbdb) { return false; }
+        // bank3_Table_for_Small_Objects_Construction_Routines
+        if (0xDbed <= addr && addr < 0xDc21) { return false; }
+        // bank3_Area_Data_Towns3
+        if (0xDcd2 <= addr && addr < 0xEfce) { return false; }
+
+        // bank3_Dialogs_Pointer_Table_Towns_in_West_Hyrule
+        if (0xEfce <= addr && addr < 0xF092) { return true; }
+
+        // Blank data
+        if (0xF813 <= addr && addr < 0xFf80) { return true; }
+
+        // bank4_Default_Palettes_for_Palaces_Type_A_B_
+        if (0x1001e <= addr && addr < 0x100fe) { return true; }
+        // bank4_Area_Pointers_Palaces_Type_A
+        if (0x10533 <= addr && addr < 0x1072b) { return false; }
+        // bank4_Area_Data
+        if (0x10c83 <= addr && addr < 0x10f26) { return false; }
+
+        // Blank data
+        if (0x12775 <= addr && addr < 0x12910) { return true; }
+
+        // Palettes for Great Palace
+        if (0x1401e <= addr && addr < 0x140fe) { return true; }
+        // bank5_Area_Data_Great_Palace2
+        if (0x14533 <= addr && addr < 0x145b1) { return false; }
+        // bank5_Area_Pointers_Great_Palace
+        if (0x14827 <= addr && addr < 0x148b0) { return false; }
+        // bank5_Area_Data_Great_Palace3
+        if (0x149e8 <= addr && addr < 0x14b41) { return false; }
+        // bank5_Ending_Text_Zelda_
+        if (0x14df1 <= addr && addr < 0x14e1a) { return true; }
+
+        // bank5_End_Credits
+        if (0x1528d <= addr && addr < 0x153bd) { return true; }
+
+        // bank5_table_intro_screen_text (Sprite credits stored at 0x16abb)
+        if (0x16942 <= addr && addr < 0x16af5) { return true; }
+        
+        // Blank data
+        if (0x17db1 <= addr && addr < 0x17f70) { return true; }
+
+        // bank7_Table_for_Overworld_Palettes
+        if (0x1c468 <= addr && addr < 0x1c48c) { return true; }
+
+        // bank7_Table_for_some_Palettes
+        if (0x1d0cd <= addr && addr < 0x1d0e1) { return true; }
+        // bank7_Tables_for_some_PPU_Command_Data
+        // Addr before Magic? icon?
+        if (0x1d0e1 <= addr && addr < 0x1d0e3) { return true; }
+        // Not allowing change of length of the MAGIC- text
+        if (0x1d0e3 == addr) { return false; }
+        // text: MAGIC-
+        if (0x1d0e4 <= addr && addr < 0x1d0ea) { return true; }
+        // Addr before Life? icon?
+        if (0x1d0ea <= addr && addr < 0x1d0ec) { return true; }
+        // Not allowing change of length of the text
+        if (0x1d0ec == addr) { return false; }
+        // text: LIFE-
+        if (0x1d0ed <= addr && addr < 0x1d0f2) { return true; }
+
+        // bank7_Continue_Save_Screen_Tile_Mappings
+        if (0x1fddb <= addr && addr < 0x1fe86) { return true; }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Basically I made a specific IpsPatcher patch method for the custom sprites. It checks every address that is being modified by a patch, and it skips changes if they are not in the whitelisted ROM address ranges. The code is very similar to the other patch method, but it didn't seem reasonable to bloat that function with a bunch of new if-checks. Better to keep it simple.

The goal is to make it impossible for custom sprites to introduce crashes or hard-to-track-down bugs. I did try it with a couple of seeds and I can't tell any difference, which is a good thing.

Everything in the CHR range has been allowed. What I did was put a breakpoint for everything it hit and ended up with a ton of ranges modified by the different IPS sprites that come included. I did my best to identify and take a stance on these ranges, but it needs a 2nd look. It can probably be shortened a fair bit too, but I didn't want to be too restrictive.

Palettes are spread all over the ROM which is the number one thing that makes this tricky, but at least palettes are easy to identify. Then there's some things like changing texts like "Magic" or the Game Over texts that I'm undecided about. I at least don't like the idea of changing the length byte of any texts like that, that would open up for bugs.

(Futher things that could be cool later is to enable a checkbox in the UI to decide whether item sprites could be overwritten, and maybe that one would be required to be off for tournaments. Just my opinion, of course.)