### PR TITLE
Enemy attributes improvements

### DIFF
--- a/RandomizerCore/Enemies.cs
+++ b/RandomizerCore/Enemies.cs
@@ -47,7 +47,7 @@ public class Enemies
         EnemiesWest.RED_DEELER,
         EnemiesWest.BLUE_DEELER,
     ];
-    public static readonly EnemiesWest[] WestGeneratorEnemies = [
+    public static readonly EnemiesWest[] WestGenerators = [
         EnemiesWest.BUBBLE_GENERATOR,
         EnemiesWest.ROCK_GENERATOR,
         EnemiesWest.BAGO_BAGO_GENERATOR,
@@ -79,7 +79,7 @@ public class Enemies
         EnemiesEast.BLUE_DEELER,
         EnemiesEast.GIRUBOKKU,
     ];
-    public static readonly EnemiesEast[] EastGeneratorEnemies = [
+    public static readonly EnemiesEast[] EastGenerators = [
         EnemiesEast.BUBBLE_GENERATOR,
         EnemiesEast.BAGO_BAGO_GENERATOR,
         EnemiesEast.BOON_GENERATOR,

--- a/RandomizerCore/Hyrule.cs
+++ b/RandomizerCore/Hyrule.cs
@@ -2233,75 +2233,61 @@ public class Hyrule
     }
 
     /// <summary>
-    /// For a given set of addresses, set a masked portion of the value of each address on or off at a rate
+    /// For a given set of bytes, set a masked portion of the value of each byte on or off (all 1's or all 0's) at a rate
     /// equal to the proportion of values at the addresses that have that masked portion set to a nonzero value.
     /// In effect, turn some values in a range on or off randomly in the proportion of the number of such values that are on in vanilla.
     /// </summary>
-    /// <param name="addr">Addresses to randomize.</param>
-    /// <param name="mask">What part of the byte value at each address contains the configuration we care about.</param>
-    /// <exception cref="ArgumentException">Iff there are 0 addresses in the space to shuffle, as this would cause a divide by zero
-    /// while determining the proportion.</exception>
-    private void RandomizeBits(ROM rom, List<int> addr, int mask = 0b00010000)
+    /// <param name="bytes">Bytes to randomize.</param>
+    /// <param name="mask">What part of the byte value at each address contains the configuration bit(s) we care about.</param>
+    private static void RandomizeBits(Random RNG, byte[] bytes, int mask)
     {
-        if(addr.Count == 0)
-        {
-            throw new ArgumentException("Cannot shuffle 0 bits");
-        }
-        int notMask = mask ^ 0xFF;
+        if (bytes.Length == 0) { return; }
 
-        double count = 0;
-        foreach (int i in addr)
-        {
-            if ((rom.GetByte(i) & mask) > 0)
-            {
-                count++;
-            }
-        }
+        int notMask = mask ^ 0xFF;
+        double vanillaBitSetCount = bytes.Where(b => (b & mask) != 0).Count();
 
         //proportion of the bytes that have nonzero values in the masked portion
-        double fraction = count / addr.Count;
+        double fraction = vanillaBitSetCount / bytes.Length;
 
-        foreach (int i in addr)
+        for (int i = 0; i < bytes.Length; i++)
         {
-            int part1 = 0;
-            int part2 = rom.GetByte(i) & notMask;
+            int v = bytes[i] & notMask;
             if (RNG.NextDouble() <= fraction)
             {
-                part1 = mask;
+                v |= mask;
             }
-            rom.Put(i, (byte)(part1 + part2));
+            bytes[i] = (byte)v;
         }
     }
 
-    private void RandomizeEnemyExp(ROM rom, List<int> addr)
+    private static void RandomizeEnemyExp(Random RNG, byte[] bytes, XPEffectiveness effectiveness)
     {
-        foreach (int i in addr)
+        for (int i = 0; i < bytes.Length; i++)
         {
-            byte exp = rom.GetByte(i);
-            int high = exp & 0xF0;
-            int low = exp & 0x0F;
+            int b = bytes[i];
+            int low = b & 0x0f;
 
-            if (props.EnemyXPDrops == XPEffectiveness.RANDOM_HIGH)
+            if (effectiveness == XPEffectiveness.RANDOM_HIGH)
             {
                 low++;
             }
-            else if (props.EnemyXPDrops == XPEffectiveness.RANDOM_LOW)
+            else if (effectiveness == XPEffectiveness.RANDOM_LOW)
             {
                 low--;
             }
-            else if (props.EnemyXPDrops == XPEffectiveness.NONE)
+            else if (effectiveness == XPEffectiveness.NONE)
             {
                 low = 0;
             }
 
-            if (props.EnemyXPDrops.IsRandom())
+            if (effectiveness.IsRandom())
             {
                 low = RNG.Next(low - 2, low + 3);
             }
 
             low = Math.Min(Math.Max(low, 0), 15);
 
-            rom.Put(i, (byte)(high + low));
+            bytes[i] = (byte)((b & 0xf0) | low);
         }
     }
 
@@ -2424,187 +2410,31 @@ public class Hyrule
             rom.Put(0x1E314, (byte)big);
         }
 
+        RandomizeEnemyAttributes(rom, 0x54e5, Enemies.WestGroundEnemies, Enemies.WestFlyingEnemies, Enemies.WestGenerators);
+        RandomizeEnemyAttributes(rom, 0x94e5, Enemies.EastGroundEnemies, Enemies.EastFlyingEnemies, Enemies.EastGenerators);
+        RandomizeEnemyAttributes(rom, 0x114e5, Enemies.Palace125GroundEnemies, Enemies.Palace125FlyingEnemies, Enemies.Palace125Generators);
+        RandomizeEnemyAttributes(rom, 0x129e5, Enemies.Palace346GroundEnemies, Enemies.Palace346FlyingEnemies, Enemies.Palace346Generators);
+        RandomizeEnemyAttributes(rom, 0x154e5, Enemies.GPGroundEnemies, Enemies.GPFlyingEnemies, Enemies.GPGenerators);
+
+        if (props.EnemyXPDrops != XPEffectiveness.VANILLA)
+        {
+            List<int> addrs = new List<int>();
+            addrs.Add(0x11505); // Horsehead
+            addrs.Add(0x13C88); // Helmethead
+            addrs.Add(0x13C89); // Gooma
+            addrs.Add(0x129EF); // Rebonak unhorsed
+            addrs.Add(0x12A05); // Rebonak
+            addrs.Add(0x12A06); // Barba
+            addrs.Add(0x12A07); // Carock
+            addrs.Add(0x15507); // Thunderbird
+            byte[] enemyBytes = addrs.Select(a => rom.GetByte(a)).ToArray();
+            RandomizeEnemyExp(RNG, enemyBytes, props.EnemyXPDrops);
+            for (int i = 0; i < addrs.Count; i++) { rom.Put(addrs[i], enemyBytes[i]); };
+        }
+
         List<int> addr = new List<int>();
-        for (int i = 0x54E8; i < 0x54ED; i++)
-        {
-            addr.Add(i);
-        }
-        for (int i = 0x54EF; i < 0x54F8; i++)
-        {
-            addr.Add(i);
-        }
-        for (int i = 0x54F9; i < 0x5508; i++)
-        {
-            addr.Add(i);
-        }
-
-        if (props.ShuffleEnemyStealExp)
-        {
-            RandomizeBits(rom, addr);
-        }
-
-        if (props.ShuffleSwordImmunity)
-        {
-            RandomizeBits(rom, addr, 0x20);
-        }
-
-        if (props.EnemyXPDrops != XPEffectiveness.VANILLA)
-        {
-            RandomizeEnemyExp(rom, addr);
-        }
-        addr = new List<int>();
-        for (int i = 0x94E8; i < 0x94ED; i++)
-        {
-            addr.Add(i);
-        }
-        for (int i = 0x94EF; i < 0x94F8; i++)
-        {
-            addr.Add(i);
-        }
-        for (int i = 0x94F9; i < 0x9502; i++)
-        {
-            addr.Add(i);
-        }
-        if (props.ShuffleEnemyStealExp)
-        {
-            RandomizeBits(rom, addr);
-        }
-
-        if (props.ShuffleSwordImmunity)
-        {
-            RandomizeBits(rom, addr, 0x20);
-        }
-        if (props.EnemyXPDrops != XPEffectiveness.VANILLA)
-        {
-            RandomizeEnemyExp(rom, addr);
-        }
-
-        addr = new List<int>();
-        for (int i = 0x114E8; i < 0x114EA; i++)
-        {
-            addr.Add(i);
-        }
-        for (int i = 0x114EB; i < 0x114ED; i++)
-        {
-            addr.Add(i);
-        }
-        for (int i = 0x114EF; i < 0x114F8; i++)
-        {
-            addr.Add(i);
-        }
-        for (int i = 0x114FD; i < 0x11505; i++)
-        {
-            addr.Add(i);
-        }
-        addr.Add(0x11508);
-
-        if (props.ShuffleEnemyStealExp)
-        {
-            RandomizeBits(rom, addr);
-        }
-
-        if (props.ShuffleSwordImmunity)
-        {
-            RandomizeBits(rom, addr, 0x20);
-        }
-        if (props.EnemyXPDrops != XPEffectiveness.VANILLA)
-        {
-            RandomizeEnemyExp(rom, addr);
-        }
-
-        addr = new List<int>();
-        for (int i = 0x129E8; i < 0x129EA; i++)
-        {
-            addr.Add(i);
-        }
-
-        for (int i = 0x129EB; i < 0x129ED; i++)
-        {
-            addr.Add(i);
-        }
-
-        for (int i = 0x129EF; i < 0x129F4; i++)
-        {
-            addr.Add(i);
-        }
-
-        for (int i = 0x129F5; i < 0x129F7; i++)
-        {
-            addr.Add(i);
-        }
-
-        for (int i = 0x129FD; i < 0x12A05; i++)
-        {
-            addr.Add(i);
-        }
-
-        addr.Add(0x12A08);
-
-        if (props.ShuffleEnemyStealExp)
-        {
-            RandomizeBits(rom, addr);
-        }
-
-        if (props.ShuffleSwordImmunity)
-        {
-            RandomizeBits(rom, addr, 0x20);
-        }
-        if (props.EnemyXPDrops != XPEffectiveness.VANILLA)
-        {
-            RandomizeEnemyExp(rom, addr);
-        }
-
-        addr = new List<int>();
-        for (int i = 0x154E9; i < 0x154ED; i++)
-        {
-            addr.Add(i);
-        }
-
-        for (int i = 0x154F2; i < 0x154F8; i++)
-        {
-            addr.Add(i);
-        }
-
-        for (int i = 0x154F9; i < 0x15500; i++)
-        {
-            addr.Add(i);
-        }
-
-        for (int i = 0x15502; i < 15504; i++)
-        {
-            addr.Add(i);
-        }
-
-        if (props.ShuffleEnemyStealExp)
-        {
-            RandomizeBits(rom, addr);
-        }
-
-        if (props.ShuffleSwordImmunity)
-        {
-            RandomizeBits(rom, addr, 0x20);
-        }
-        if (props.EnemyXPDrops != XPEffectiveness.VANILLA)
-        {
-            RandomizeEnemyExp(rom, addr);
-        }
-
-        if (props.EnemyXPDrops != XPEffectiveness.VANILLA)
-        {
-            addr = new List<int>();
-            addr.Add(0x11505);
-            addr.Add(0x13C88);
-            addr.Add(0x13C89);
-            addr.Add(0x12A05);
-            addr.Add(0x12A06);
-            addr.Add(0x12A07);
-            addr.Add(0x15507);
-            RandomizeEnemyExp(rom, addr);
-        }
-
         if (props.ShuffleEncounters)
         {
-            addr = new List<int>();
             addr.Add(0x441b); // 0x62: West northern grass
             addr.Add(0x4419); // 0x5D: West northern desert
             addr.Add(0x441D); // 0x67: West northern forest
@@ -2709,6 +2539,35 @@ public class Hyrule
             rom.Put(0x1E8B0, (byte)drop);
         }
 
+    }
+
+    private void RandomizeEnemyAttributes<T>(ROM rom, int baseAddr, T[] groundEnemies, T[] flyingEnemies, T[] generators) where T : Enum
+    {
+        List<T> allEnemies = [.. groundEnemies, .. flyingEnemies, .. generators];
+        var addrsByte = allEnemies.Select(n => baseAddr + (int)(object)n).ToList();
+        byte[] enemyBytes = addrsByte.Select(a => rom.GetByte(a)).ToArray();
+
+        // enemy attributes byte1
+        // ..x. .... sword immune
+        // ...x .... steals exp
+        // .... xxxx exp
+        const int SWORD_IMMUNE_BIT = 0b00100000;
+        const int XP_STEAL_BIT =     0b00010000;
+
+        if (props.ShuffleSwordImmunity)
+        {
+            RandomizeBits(RNG, enemyBytes, SWORD_IMMUNE_BIT);
+        }
+        if (props.ShuffleEnemyStealExp)
+        {
+            RandomizeBits(RNG, enemyBytes, XP_STEAL_BIT);
+        }
+        if (props.EnemyXPDrops != XPEffectiveness.VANILLA)
+        {
+            RandomizeEnemyExp(RNG, enemyBytes, props.EnemyXPDrops);
+        }
+
+        for (int i = 0; i < addrsByte.Count; i++) { rom.Put(addrsByte[i], enemyBytes[i]); }
     }
 
     private byte IntToText(int x)

--- a/RandomizerCore/Overworld/DeathMountain.cs
+++ b/RandomizerCore/Overworld/DeathMountain.cs
@@ -145,7 +145,7 @@ sealed class DeathMountain : World
     {
         var groundEnemies = Enemies.WestGroundEnemies;
         var flyingEnemies = Enemies.WestFlyingEnemies;
-        var generators = Enemies.WestGeneratorEnemies;
+        var generators = Enemies.WestGenerators;
         var smallEnemies = Enemies.WestSmallEnemies;
         var largeEnemies = Enemies.WestLargeEnemies;
         var ee = new Sidescroll.EnemiesEditable<EnemiesWest>(enemyBytes);

--- a/RandomizerCore/Overworld/EastHyrule.cs
+++ b/RandomizerCore/Overworld/EastHyrule.cs
@@ -259,7 +259,7 @@ public sealed class EastHyrule : World
     {
         var groundEnemies = Enemies.EastGroundEnemies;
         var flyingEnemies = Enemies.EastFlyingEnemies;
-        var generators = Enemies.EastGeneratorEnemies;
+        var generators = Enemies.EastGenerators;
         var smallEnemies = Enemies.EastSmallEnemies;
         var largeEnemies = Enemies.EastLargeEnemies;
         var ee = new Sidescroll.EnemiesEditable<EnemiesEast>(enemyBytes);

--- a/RandomizerCore/Overworld/MazeIsland.cs
+++ b/RandomizerCore/Overworld/MazeIsland.cs
@@ -69,7 +69,7 @@ sealed class MazeIsland : World
     {
         var groundEnemies = Enemies.EastGroundEnemies;
         var flyingEnemies = Enemies.EastFlyingEnemies;
-        var generators = Enemies.EastGeneratorEnemies;
+        var generators = Enemies.EastGenerators;
         var smallEnemies = Enemies.EastSmallEnemies;
         var largeEnemies = Enemies.EastLargeEnemies;
         var ee = new Sidescroll.EnemiesEditable<EnemiesEast>(enemyBytes);

--- a/RandomizerCore/Overworld/WestHyrule.cs
+++ b/RandomizerCore/Overworld/WestHyrule.cs
@@ -323,7 +323,7 @@ public sealed class WestHyrule : World
     {
         var groundEnemies = Enemies.WestGroundEnemies;
         var flyingEnemies = Enemies.WestFlyingEnemies;
-        var generators = Enemies.WestGeneratorEnemies;
+        var generators = Enemies.WestGenerators;
         var smallEnemies = Enemies.WestSmallEnemies;
         var largeEnemies = Enemies.WestLargeEnemies;
         var ee = new Sidescroll.EnemiesEditable<EnemiesWest>(enemyBytes);

--- a/RandomizerCore/Sidescroll/EnemiesEditable.cs
+++ b/RandomizerCore/Sidescroll/EnemiesEditable.cs
@@ -249,9 +249,9 @@ public class Enemy<T> where T : Enum
         switch (this)
         {
             case Enemy<EnemiesWest>:
-                return Enemies.WestGeneratorEnemies.Any(e => e.Equals(Id));
+                return Enemies.WestGenerators.Any(e => e.Equals(Id));
             case Enemy<EnemiesEast>:
-                return Enemies.EastGeneratorEnemies.Any(e => e.Equals(Id));
+                return Enemies.EastGenerators.Any(e => e.Equals(Id));
             case Enemy<EnemiesPalace125>:
                 return Enemies.StandardPalaceGenerators.Contains(IdByte);
             case Enemy<EnemiesPalace346>:


### PR DESCRIPTION
I did some more work here to try to have less logic functions writing directly to the ROM bytes. Also a lot of the magic number addresses could be cleaned up now!

[Extract cleaner RandomizeEnemyAttributes method from RandomizeStartingValues](https://github.com/Ellendar/Z2Randomizer/commit/35db97972e9b3b3813ef0636f7bc5e9bc1dee355) 

This also adds a few missing enemies from the XP randomization:
- Blue dragon heads in Palace 125
- Mew, Acheman, Fokkeru (Spicy Chickens), King bots in GP

[Enemies that roll sword immune are set to be damageable by Fire](https://github.com/Ellendar/Z2Randomizer/commit/861fd098e7eaf3e870358fd2298ee58cd6586a42)
