### PR TITLE
More enemy positioning improvements

### DIFF
--- a/RandomizerCore/Overworld/DeathMountain.cs
+++ b/RandomizerCore/Overworld/DeathMountain.cs
@@ -122,7 +122,14 @@ sealed class DeathMountain : World
         enemyAddr = 0x48B0;
         enemyPtr = 0x608E;
 
-        overworldMaps = new List<int>();
+        overworldEncounterMaps = [
+            29, 30, // Desert
+            34, 35, // Grass (not in Vanilla)
+            39, 40, // Forest
+            47, 48, // Swamp (not in Vanilla)
+            52, 53, // Graveyard
+        ];
+
         MAP_ROWS = 45;
         MAP_COLS = 64;
 
@@ -144,7 +151,7 @@ sealed class DeathMountain : World
         SetVanillaCollectables(props.ReplaceFireWithDash);
     }
 
-    protected override byte[] RandomizeEnemies(List<byte[]> sideviewBytes, byte[] enemyBytes, bool mixLargeAndSmallEnemies, bool generatorsAlwaysMatch)
+    protected override byte[] RandomizeEnemies(List<byte[]> sideviewBytes, byte[] enemyBytes, bool encounter, bool mixLargeAndSmallEnemies, bool generatorsAlwaysMatch)
     {
         var groundEnemies = Enemies.WestGroundEnemies;
         var flyingEnemies = Enemies.WestFlyingEnemies;
@@ -152,7 +159,7 @@ sealed class DeathMountain : World
         var smallEnemies = Enemies.WestSmallEnemies;
         var largeEnemies = Enemies.WestLargeEnemies;
         var ee = new Sidescroll.EnemiesEditable<EnemiesWest>(enemyBytes);
-        RandomizeEnemiesInner(sideviewBytes, ee, mixLargeAndSmallEnemies, generatorsAlwaysMatch, RNG, groundEnemies, smallEnemies, largeEnemies, flyingEnemies, generators);
+        RandomizeEnemiesInner(sideviewBytes, ee, encounter, mixLargeAndSmallEnemies, generatorsAlwaysMatch, RNG, groundEnemies, smallEnemies, largeEnemies, flyingEnemies, generators);
         return ee.Finalize();
     }
 

--- a/RandomizerCore/Overworld/EastHyrule.cs
+++ b/RandomizerCore/Overworld/EastHyrule.cs
@@ -152,6 +152,16 @@ public sealed class EastHyrule : World
 
         enemyAddr = 0x88B0;
         enemyPtr = 0x85B1;
+
+        overworldEncounterMaps = [
+            29, 30, // Desert
+            34, 35, // Grass
+            39, 40, // Forest
+            47, 48, // Swamp
+            52, 53, // Graveyard
+            59, 60, // Lava
+        ];
+
         locationAtGP = GetLocationByMem(0x8665);
         locationAtGP.PalaceNumber = 7;
         locationAtGP.VanillaCollectable = locationAtGP.Collectable = Collectable.DO_NOT_USE;
@@ -191,8 +201,6 @@ public sealed class EastHyrule : World
         daruniaRoof.CanShuffle = false;
         townAtDarunia.Children.Add(daruniaRoof);
         AddLocation(daruniaRoof);
-
-        overworldMaps = [29, 30, 34, 35, 39, 40, 48, 53, 60];
 
         MAP_ROWS = 75;
         MAP_COLS = 64;
@@ -258,7 +266,7 @@ public sealed class EastHyrule : World
         SetVanillaCollectables(props.ReplaceFireWithDash);
     }
 
-    protected override byte[] RandomizeEnemies(List<byte[]> sideviewBytes, byte[] enemyBytes, bool mixLargeAndSmallEnemies, bool generatorsAlwaysMatch)
+    protected override byte[] RandomizeEnemies(List<byte[]> sideviewBytes, byte[] enemyBytes, bool encounter, bool mixLargeAndSmallEnemies, bool generatorsAlwaysMatch)
     {
         var groundEnemies = Enemies.EastGroundEnemies;
         var flyingEnemies = Enemies.EastFlyingEnemies;
@@ -266,7 +274,7 @@ public sealed class EastHyrule : World
         var smallEnemies = Enemies.EastSmallEnemies;
         var largeEnemies = Enemies.EastLargeEnemies;
         var ee = new Sidescroll.EnemiesEditable<EnemiesEast>(enemyBytes);
-        RandomizeEnemiesInner(sideviewBytes, ee, mixLargeAndSmallEnemies, generatorsAlwaysMatch, RNG, groundEnemies, smallEnemies, largeEnemies, flyingEnemies, generators);
+        RandomizeEnemiesInner(sideviewBytes, ee, encounter, mixLargeAndSmallEnemies, generatorsAlwaysMatch, RNG, groundEnemies, smallEnemies, largeEnemies, flyingEnemies, generators);
         return ee.Finalize();
     }
 

--- a/RandomizerCore/Overworld/MazeIsland.cs
+++ b/RandomizerCore/Overworld/MazeIsland.cs
@@ -52,7 +52,7 @@ sealed class MazeIsland : World
         walkableTerrains = [Terrain.MOUNTAIN];
         enemyAddr = 0x88B0;
         enemyPtr = 0xA08E;
-        overworldMaps = [];
+        overworldEncounterMaps = [];
 
         childDrop = GetLocationByMem(0xA143);
         magicContainerDrop = GetLocationByMem(0xA133);
@@ -68,7 +68,7 @@ sealed class MazeIsland : World
         SetVanillaCollectables(props.ReplaceFireWithDash);
     }
 
-    protected override byte[] RandomizeEnemies(List<byte[]> sideviewBytes, byte[] enemyBytes, bool mixLargeAndSmallEnemies, bool generatorsAlwaysMatch)
+    protected override byte[] RandomizeEnemies(List<byte[]> sideviewBytes, byte[] enemyBytes, bool encounter, bool mixLargeAndSmallEnemies, bool generatorsAlwaysMatch)
     {
         var groundEnemies = Enemies.EastGroundEnemies;
         var flyingEnemies = Enemies.EastFlyingEnemies;
@@ -76,7 +76,7 @@ sealed class MazeIsland : World
         var smallEnemies = Enemies.EastSmallEnemies;
         var largeEnemies = Enemies.EastLargeEnemies;
         var ee = new Sidescroll.EnemiesEditable<EnemiesEast>(enemyBytes);
-        RandomizeEnemiesInner(sideviewBytes, ee, mixLargeAndSmallEnemies, generatorsAlwaysMatch, RNG, groundEnemies, smallEnemies, largeEnemies, flyingEnemies, generators);
+        RandomizeEnemiesInner(sideviewBytes, ee, encounter, mixLargeAndSmallEnemies, generatorsAlwaysMatch, RNG, groundEnemies, smallEnemies, largeEnemies, flyingEnemies, generators);
         return ee.Finalize();
     }
 

--- a/RandomizerCore/Overworld/WestHyrule.cs
+++ b/RandomizerCore/Overworld/WestHyrule.cs
@@ -227,7 +227,13 @@ public sealed class WestHyrule : World
         enemyAddr = 0x48B0;
         enemyPtr = 0x45B1;
 
-        overworldMaps = [29, 30, 34, 35, 39, 40, 48, 53, 58];
+        overworldEncounterMaps = [
+            29, 30, // Desert
+            34, 35, // Grass
+            39, 40, // Forest
+            47, 48, // Swamp
+            52, 53, // Graveyard
+        ];
 
         MAP_ROWS = 75;
         MAP_COLS = 64;
@@ -322,7 +328,7 @@ public sealed class WestHyrule : World
         SetVanillaCollectables(props.ReplaceFireWithDash);
     }
 
-    protected override byte[] RandomizeEnemies(List<byte[]> sideviewBytes, byte[] enemyBytes, bool mixLargeAndSmallEnemies, bool generatorsAlwaysMatch)
+    protected override byte[] RandomizeEnemies(List<byte[]> sideviewBytes, byte[] enemyBytes, bool encounter, bool mixLargeAndSmallEnemies, bool generatorsAlwaysMatch)
     {
         var groundEnemies = Enemies.WestGroundEnemies;
         var flyingEnemies = Enemies.WestFlyingEnemies;
@@ -330,7 +336,7 @@ public sealed class WestHyrule : World
         var smallEnemies = Enemies.WestSmallEnemies;
         var largeEnemies = Enemies.WestLargeEnemies;
         var ee = new Sidescroll.EnemiesEditable<EnemiesWest>(enemyBytes);
-        RandomizeEnemiesInner(sideviewBytes, ee, mixLargeAndSmallEnemies, generatorsAlwaysMatch, RNG, groundEnemies, smallEnemies, largeEnemies, flyingEnemies, generators);
+        RandomizeEnemiesInner(sideviewBytes, ee, encounter, mixLargeAndSmallEnemies, generatorsAlwaysMatch, RNG, groundEnemies, smallEnemies, largeEnemies, flyingEnemies, generators);
         return ee.Finalize();
     }
 

--- a/RandomizerCore/Overworld/World.cs
+++ b/RandomizerCore/Overworld/World.cs
@@ -252,7 +252,7 @@ public abstract class World
                 }
             }
         }
-        void PositionSmallEnemy(Sidescroll.Enemy<T> enemy, T swapToId)
+        bool PositionSmallEnemy(Sidescroll.Enemy<T> enemy, T swapToId)
         {
             switch (swapToId)
             {
@@ -261,13 +261,21 @@ public abstract class World
                     {
                         enemy.Y -= 1;
                     }
-                    break;
+                    return true;
                 case EnemiesEast.LEEVER:
-                    enemy.Y = Math.Min(9, Sidescroll.SolidGridHelper.FindFloor(solidGrid, enemy.X, enemy.Y, 1, 1));
-                    break;
+                    // Vanilla Leever positions for reference:
+                    // East Map 29 Small & Large encounter at y == 8
+                    // East Map 30 Large encounter at y == 8
+                    // East Map 33 at y == 9
+                    var floor = Sidescroll.SolidGridHelper.FindFloor(solidGrid, enemy.X, enemy.Y, 1, 1);
+                    if (floor < 8) {
+                        return false; // Don't roll Leevers above ground level
+                    }
+                    enemy.Y = Math.Min(9, floor); // Leever y > 9 warps to spawning from the top of the screen
+                    return true;
                 default:
                     enemy.Y = Sidescroll.SolidGridHelper.FindFloor(solidGrid, enemy.X, enemy.Y, 1, 1);
-                    break;
+                    return true;
             }
         }
         void PositionLargeEnemy(Sidescroll.Enemy<T> enemy, T swapToId)
@@ -281,6 +289,18 @@ public abstract class World
                     enemy.Y = Sidescroll.SolidGridHelper.FindFloor(solidGrid, enemy.X, enemy.Y, 1, 2);
                     break;
             }
+        }
+        T RollSmallEnemy(Sidescroll.Enemy<T> enemy, T swapToId)
+        {
+            while (true)
+            {
+                if (PositionSmallEnemy(enemy, swapToId))
+                {
+                    break;
+                }
+                swapToId = flyingEnemies[RNG.Next(0, flyingEnemies.Length)];
+            }
+            return swapToId;
         }
 
         int? firstGenerator = null;
@@ -303,7 +323,7 @@ public abstract class World
                     }
                     else
                     {
-                        PositionSmallEnemy(enemy, swapToId);
+                        swapToId = RollSmallEnemy(enemy, swapToId);
                     }
                     enemy.Id = swapToId;
                     continue;
@@ -321,7 +341,7 @@ public abstract class World
                 else if (enemy.IsShufflableSmall())
                 {
                     T swapToId = smallEnemies[RNG.Next(0, smallEnemies.Length)];
-                    PositionSmallEnemy(enemy, swapToId);
+                    swapToId = RollSmallEnemy(enemy, swapToId);
                     enemy.Id = swapToId;
                     continue;
                 }

--- a/RandomizerCore/Overworld/World.cs
+++ b/RandomizerCore/Overworld/World.cs
@@ -19,7 +19,7 @@ public abstract class World
     protected int sideviewBank;
     protected int enemyAddr;
     protected int enemyPtr;
-    protected List<int> overworldMaps;
+    protected List<int> overworldEncounterMaps;
     protected SortedDictionary<(int, int), Location> locsByCoords;
     protected Terrain[,] map;
     protected int MAP_ROWS;
@@ -189,9 +189,9 @@ public abstract class World
         }
     }
 
-    protected abstract byte[] RandomizeEnemies(List<byte[]> sideviewBytes, byte[] enemyBytes, bool mixLargeAndSmallEnemies, bool generatorsAlwaysMatch);
+    protected abstract byte[] RandomizeEnemies(List<byte[]> sideviewBytes, byte[] enemyBytes, bool encounter, bool mixLargeAndSmallEnemies, bool generatorsAlwaysMatch);
 
-    public void ShuffleEnemies(ROM romData, SortedSet<int> sideviewAddr, int enemiesAddr, bool mixLargeAndSmallEnemies, bool generatorsAlwaysMatch)
+    public void ShuffleEnemies(ROM romData, SortedSet<int> sideviewAddr, int enemiesAddr, bool encounter, bool mixLargeAndSmallEnemies, bool generatorsAlwaysMatch)
     {
         if (enemiesAddr == 0x4A88)
         {
@@ -209,12 +209,12 @@ public abstract class World
         List<byte[]> sideviewBytes = [.. sideviewAddr.Select(a => romData.GetBytes(a, romData.GetByte(a)))];
         int enemiesLength = romData.GetByte(enemiesAddr);
         byte[] enemiesBytes = romData.GetBytes(enemiesAddr, enemiesLength);
-        byte[] newEnemyBytes = RandomizeEnemies(sideviewBytes, enemiesBytes, mixLargeAndSmallEnemies, generatorsAlwaysMatch);
+        byte[] newEnemyBytes = RandomizeEnemies(sideviewBytes, enemiesBytes, encounter, mixLargeAndSmallEnemies, generatorsAlwaysMatch);
         Debug.Assert(newEnemyBytes.Length == enemiesLength);
         romData.Put(enemiesAddr, newEnemyBytes);
     }
 
-    protected void RandomizeEnemiesInner<T>(List<byte[]> sideviewBytes, Sidescroll.EnemiesEditable<T> ee, bool mixLargeAndSmallEnemies, bool generatorsAlwaysMatch, Random RNG, T[] groundEnemies, T[] smallEnemies, T[] largeEnemies, T[] flyingEnemies, T[] generators) where T : Enum
+    protected void RandomizeEnemiesInner<T>(List<byte[]> sideviewBytes, Sidescroll.EnemiesEditable<T> ee, bool encounter, bool mixLargeAndSmallEnemies, bool generatorsAlwaysMatch, Random RNG, T[] groundEnemies, T[] smallEnemies, T[] largeEnemies, T[] flyingEnemies, T[] generators) where T : Enum
     {
         Debug.Assert(sideviewBytes.Count > 0);
         bool[,]? solidGrid = null;
@@ -234,10 +234,10 @@ public abstract class World
                 solidGrid = Sidescroll.SolidGridHelper.GridUnion(solidGrid, svGrid);
             }
         }
-        RandomizeEnemiesInner(solidGrid!, ee, mixLargeAndSmallEnemies, generatorsAlwaysMatch, RNG, groundEnemies, smallEnemies, largeEnemies, flyingEnemies, generators);
+        RandomizeEnemiesInner(solidGrid!, ee, encounter, mixLargeAndSmallEnemies, generatorsAlwaysMatch, RNG, groundEnemies, smallEnemies, largeEnemies, flyingEnemies, generators);
     }
 
-    protected void RandomizeEnemiesInner<T>(bool[,] solidGrid, Sidescroll.EnemiesEditable<T> ee, bool mixLargeAndSmallEnemies, bool generatorsAlwaysMatch, Random RNG, T[] groundEnemies, T[] smallEnemies, T[] largeEnemies, T[] flyingEnemies, T[] generators) where T : Enum
+    protected void RandomizeEnemiesInner<T>(bool[,] solidGrid, Sidescroll.EnemiesEditable<T> ee, bool encounter, bool mixLargeAndSmallEnemies, bool generatorsAlwaysMatch, Random RNG, T[] groundEnemies, T[] smallEnemies, T[] largeEnemies, T[] flyingEnemies, T[] generators) where T : Enum
     {
         void PositionGeldarm(Sidescroll.Enemy<T> enemy)
         {
@@ -302,6 +302,26 @@ public abstract class World
             }
             return swapToId;
         }
+        void MoveAwayFromLinkSpawnInEncounter(Sidescroll.Enemy<T> enemy)
+        {
+            if (encounter)
+            {
+                // Move ground enemies in encounters away from Link's spawning position at x == 24
+                // Geldarms are the only ones that appear very close in vanilla, so those are allowed.
+                int minSpace = enemy.Id is EnemiesWest.GELDARM ? 1 : 4;
+                var x = enemy.X;
+                var maxLeft = 24 - minSpace - 1;
+                var minRight = 24 + minSpace + 1;
+                if (maxLeft < x && x <= 24)
+                {
+                    enemy.X = maxLeft;
+                }
+                else if (24 < x && x < minRight)
+                {
+                    enemy.X = minRight;
+                }
+            }
+        }
 
         int? firstGenerator = null;
         for (int i = 0; i < ee.Enemies.Count; i++)
@@ -326,6 +346,7 @@ public abstract class World
                         swapToId = RollSmallEnemy(enemy, swapToId);
                     }
                     enemy.Id = swapToId;
+                    MoveAwayFromLinkSpawnInEncounter(enemy);
                     continue;
                 }
             }
@@ -336,6 +357,7 @@ public abstract class World
                     T swapToId = largeEnemies[RNG.Next(0, largeEnemies.Length)];
                     PositionLargeEnemy(enemy, swapToId);
                     enemy.Id = swapToId;
+                    MoveAwayFromLinkSpawnInEncounter(enemy);
                     continue;
                 }
                 else if (enemy.IsShufflableSmall())
@@ -343,6 +365,7 @@ public abstract class World
                     T swapToId = smallEnemies[RNG.Next(0, smallEnemies.Length)];
                     swapToId = RollSmallEnemy(enemy, swapToId);
                     enemy.Id = swapToId;
+                    MoveAwayFromLinkSpawnInEncounter(enemy);
                     continue;
                 }
             }
@@ -465,6 +488,7 @@ public abstract class World
         // rooms sometimes, it seemed best to keep track of all of them
         // to make the enemies fit into every one of the linked sideviews.
         SortedDictionary<int, SortedSet<int>> dict = new();
+        HashSet<int> encounterAddrs = new();
         for (int map = 0; map < 63; map++)
         {
             int i = enemyPtr + map * 2;
@@ -480,11 +504,12 @@ public abstract class World
             }
         }
         // encounters have a second enemy list (small & large encounter)
-        foreach (int map in overworldMaps)
+        foreach (int map in overworldEncounterMaps)
         {
             int i = enemyPtr + map * 2;
             int enemiesPtrOffset = romData.GetShort(i + 1, i) & 0x0FFF;
             int addr = enemyAddr + enemiesPtrOffset;
+            encounterAddrs.Add(addr);
             byte enemiesLength = romData.GetByte(addr);
             addr += enemiesLength; // go past first enemy list
 
@@ -495,11 +520,12 @@ public abstract class World
             {
                 dict[addr].Add(sideviewAddr); // add to existing set
             }
+            encounterAddrs.Add(addr);
         }
 
         foreach(var(eAddr, svAddrs) in dict)
         {
-            ShuffleEnemies(romData, svAddrs, eAddr, mixLargeAndSmallEnemies, generatorsAlwaysMatch);
+            ShuffleEnemies(romData, svAddrs, eAddr, encounterAddrs.Contains(eAddr), mixLargeAndSmallEnemies, generatorsAlwaysMatch);
         }
     }
 

--- a/RandomizerCore/Sidescroll/Room.cs
+++ b/RandomizerCore/Sidescroll/Room.cs
@@ -433,6 +433,44 @@ public class Room : IJsonOnDeserialized
             }
             return cachedResult.Value;
         }
+        bool PositionKingBot(ref bool? cachedResult, Enemy<T> enemy)
+        {
+            // Vanilla King Bot positions for reference:
+            // GP Map 37 at y == 1 where floor is at y == 8
+            // GP Map 48 at y == 3 where floor is at y == 11
+
+            // Do our best to position King Bots high up, so they are unlikely to
+            // spawn inside the player's position.  y==3 is the preferred spot unless
+            // the floor is high, as there is also the risk of having the King Bot
+            // spawn in your position when you are Fairying over a room.
+            // (Enemies in Zelda II cannot be positioned at y == 0 or y == 2.)
+
+            // Unless we find a 3x6 empty area here we will not spawn a King Bot.
+            if (cachedResult == null)
+            {
+                var solidGrid = GetSolidGrid<GreatPalaceObject>();
+
+                int newY = 0;
+                foreach (int j in new int[] { 3, 4, 1, 5 })
+                {
+                    if (SolidGridHelper.AreaIsOpen(solidGrid, enemy.X, j, 3, 6))
+                    {
+                        newY = j;
+                        break;
+                    }
+                }
+                if (newY != 0)
+                {
+                    enemy.Y = newY;
+                    cachedResult = true;
+                }
+                else
+                {
+                    cachedResult = false;
+                }
+            }
+            return cachedResult.Value;
+        }
 
         T RerollLargeEnemyIfNeeded(Enemy<T> enemy, T swapToId)
         {
@@ -504,7 +542,7 @@ public class Room : IJsonOnDeserialized
                             break;
 
                         case EnemiesGreatPalace.KING_BOT:
-                            reroll = !AreaIsOpen<GreatPalaceObject>(ref roomForKingBot, enemy.X, enemy.Y, 3, 2);
+                            reroll = !PositionKingBot(ref roomForKingBot, enemy); // updates enemy position on success
                             break;
                     };
 

--- a/RandomizerCore/Sidescroll/SideviewEditable.cs
+++ b/RandomizerCore/Sidescroll/SideviewEditable.cs
@@ -94,6 +94,18 @@ public class SideviewEditable<T> where T : Enum
         set { Header[2] = (byte)((Header[2] & 0b10001111) | ((value & 0b0111) << 4)); }
     }
 
+    public byte SpritePalette
+    {
+        get { return (byte)((Header[3] & 0b11000000) >> 6); }
+        set { Header[3] = (byte)((Header[3] & 0b00111111) | ((value & 0b11) << 6)); }
+    }
+
+    public byte BackgroundPalette
+    {
+        get { return (byte)((Header[3] & 0b00111000) >> 3); }
+        set { Header[3] = (byte)((Header[3] & 0b11000111) | ((value & 0b111) << 3)); }
+    }
+
     public byte BackgroundMap
     {
         get { return (byte)(Header[3] & 0b00000111); }


### PR DESCRIPTION
I've done some further enemy positioning improvements.

[Add logic to re-position King Bots higher above the ground](https://github.com/Ellendar/Z2Randomizer/commit/2ff6c9aa79f6ac3e90954ee5f0946857f6428f0a)
- This should help with King Bots spawning right in the players face, while also positioning them more true to vanilla Z2.

[Improve Leever enemy positioning](https://github.com/Ellendar/Z2Randomizer/commit/7d816ce8be301d3596b92ebf7c2ad51d7d52152e)
- Handle Leevers similar to Wizards that they should only be at ground level, with a bit more leniancy. (The problem with them being positioned higher being that Leevers teleport around doing instant contact damage. In vanilla they only teleport to buried positions and then come out from the ground.)

[Allow Link to spawn safely in Overworld encounters (move close enemies)](https://github.com/Ellendar/Z2Randomizer/commit/fc6b6fa1ead46448924e6ed078c07b5b0606bd11)
- There are some Overworld encounters (especially in Death Mountain) where enemies spawn way too cloesly to where Link starts. This fixes that by moving those enemies away from Link's starting position.