### PR TITLE
Random palace item room count *per palace* with visual indicators

### DIFF
--- a/RandomizerCore/Hyrule.cs
+++ b/RandomizerCore/Hyrule.cs
@@ -1329,7 +1329,7 @@ public class Hyrule
         foreach (Location location in delayedEvaluationLocations)
         {
             bool canGet;
-            if (location.ActualTown != null & Towns.townSpellAndItemRequirements.ContainsKey((Town)location.ActualTown!))
+            if (location.ActualTown != null && Towns.townSpellAndItemRequirements.ContainsKey((Town)location.ActualTown))
             {
                 canGet = CanGet(location) && Towns.townSpellAndItemRequirements[(Town)location.ActualTown!].AreSatisfiedBy(requireables);
             }

--- a/RandomizerCore/Hyrule.cs
+++ b/RandomizerCore/Hyrule.cs
@@ -458,7 +458,7 @@ public class Hyrule
                     sb.AppendLine("Palace: " + palace.Number);
                     foreach (Room room in palace.AllRooms.OrderBy(i => i.Map))
                     {
-                        sb.AppendLine(room.Debug());
+                        sb.AppendLine(room.DebugString());
                     }
                     File.WriteAllText("rooms.log", sb.ToString());
                 }
@@ -806,36 +806,34 @@ public class Hyrule
         }
 
         //palace items beyond the first are excess
-        for(int i = 0; i < int.Max(props.PalaceItemRoomCount - 1, 0) * 6; i++)
+        int extraPalaceItemCount = props.PalaceItemRoomCounts.Select(c => Math.Max(c - 1, 0)).Sum();
+        for (int i = 0; i < extraPalaceItemCount; i++)
         {
             shufflableItems.Add(smallItems.Sample(RNG));
         }
 
+
+        List<Collectable> vanillaPalaceItems = [Collectable.CANDLE, Collectable.GLOVE, Collectable.RAFT, Collectable.BOOTS, Collectable.FLUTE, Collectable.CROSS];
+
         //No palace items handling
-        if (props.PalaceItemRoomCount == 0)
+        for (int i = 0; i < 6; i++)
         {
-            excessItems.AddRange([Collectable.CANDLE, Collectable.GLOVE, Collectable.RAFT, 
-                Collectable.BOOTS, Collectable.FLUTE, Collectable.CROSS]);
-            excessItems.RemoveAll(props.StartsWithCollectable);
-
-            int removedPalaceItems = shufflableItems.Count;
-            excessItems.ForEach(i => shufflableItems.Remove(i));
-            removedPalaceItems -= shufflableItems.Count;
-
-            //Palace items you started with couldn't be removed in the previous step, so remove them now.
-            int palaceSmallItemCount = (props.StartCandle ? 1 : 0) + (props.StartGlove ? 1 : 0) + (props.StartRaft ? 1 : 0) +
-                (props.StartBoots ? 1 : 0) + (props.StartFlute ? 1 : 0) + (props.StartCross ? 1 : 0);
-            List<Collectable> shufflableItemsCopy = [.. shufflableItems];
-            int removedItems = 0;
-            for (int i = 0; i < shufflableItems.Count && palaceSmallItemCount > 0; i++)
+            if (props.PalaceItemRoomCounts[i] == 0)
             {
-                if (shufflableItems[i].IsMinorItem())
+                var vanillaPalaceItem = vanillaPalaceItems[i];
+                if (props.StartsWithCollectable(vanillaPalaceItem))
                 {
-                    shufflableItemsCopy.RemoveAt(i - removedItems++);
-                    palaceSmallItemCount--;
+                    // since the palace item is replaced by a minor item, remove a minor item from the shuffle
+                    var firstMinorItemIndex = shufflableItems.FindIndex(c => c.IsMinorItem());
+                    Debug.Assert(firstMinorItemIndex != -1);
+                    shufflableItems.RemoveAt(firstMinorItemIndex);
+                }
+                else
+                {
+                    excessItems.Add(vanillaPalaceItem);
+                    shufflableItems.Remove(vanillaPalaceItem);
                 }
             }
-            shufflableItems = shufflableItemsCopy;
         }
 
         List<int> minorItemIndexes = [];
@@ -907,7 +905,7 @@ public class Hyrule
                 }
             }
         }
-        if(shufflableItems.Count != itemLocs.Count + Math.Max((props.PalaceItemRoomCount * 6) - 6,0))
+        if(shufflableItems.Count != itemLocs.Count + extraPalaceItemCount)
         {
             throw new Exception("Item locations must match number of items");
         }
@@ -921,21 +919,23 @@ public class Hyrule
         {
             if(location?.PalaceNumber == null)
             {
-                itemLocsIterator.MoveNext();
+                if (!itemLocsIterator.MoveNext()) { throw new InvalidOperationException("Ran out of item locations."); }
                 location = itemLocsIterator.Current;
             }
-            while(location.PalaceNumber != null && ++subIndex > props.PalaceItemRoomCount)
+            while(location.PalaceNumber is int palaceNum && ++subIndex > props.PalaceItemRoomCounts[palaceNum - 1])
             {
                 subIndex = 0;
-                itemLocsIterator.MoveNext();
+                if (!itemLocsIterator.MoveNext()) { throw new InvalidOperationException("Ran out of item locations."); }
                 location = itemLocsIterator.Current;
             }
+
             location.Collectables.Add(item);
-            if(location.PalaceNumber != null)
+            if(location.PalaceNumber is int palaceNumInIf)
             {
-                palaces[(location.PalaceNumber ?? 0) - 1].ItemRooms[subIndex - 1].Collectable = item;
+                palaces[palaceNumInIf - 1].ItemRooms[subIndex - 1].Collectable = item;
             }
         }
+        Debug.Assert(!itemLocsIterator.MoveNext(), "All item locations were not used. This should not happen.");
     }
 
     private async Task<bool> FillPalaceRooms(AsmModule sideviewModule)
@@ -1942,7 +1942,7 @@ public class Hyrule
                     westHyrule.SetStart();
 
                     ShufflePalaces();
-                    LoadItemLocs(props.PalaceItemRoomCount);
+                    LoadItemLocs(props.PalaceItemRoomCounts);
                     ShuffleItems();
 
 
@@ -2091,7 +2091,7 @@ public class Hyrule
 
     //ItemLocs is specifically only those locations that contain shufflable items
     //If you're looking for a global reference for which items are where... too bad it doesn't exist :(
-    private List<Location> LoadItemLocs(int itemsPerPalace)
+    private List<Location> LoadItemLocs(int[] itemsPerPalaces)
     {
         itemLocs =
         [
@@ -2149,15 +2149,15 @@ public class Hyrule
             itemLocs.Add(eastHyrule.daruniaRoof);
         }
 
-        if(props.PalaceItemRoomCount == 0)
-        {
-            itemLocs.Remove(westHyrule.locationAtPalace1);
-            itemLocs.Remove(westHyrule.locationAtPalace2);
-            itemLocs.Remove(westHyrule.locationAtPalace3);
-            itemLocs.Remove(mazeIsland.locationAtPalace4);
-            itemLocs.Remove(eastHyrule.locationAtPalace5);
-            itemLocs.Remove(eastHyrule.locationAtPalace6);
-            itemLocs.Remove(eastHyrule.locationAtGP);
+        List<Location> pals = [westHyrule.locationAtPalace1, westHyrule.locationAtPalace2, westHyrule.locationAtPalace3, mazeIsland.locationAtPalace4, eastHyrule.locationAtPalace5, eastHyrule.locationAtPalace6, eastHyrule.locationAtGP];
+        foreach (var pal in pals) {
+            if (pal.PalaceNumber is int palaceNum)
+            {
+                if (palaceNum == 7 || props.PalaceItemRoomCounts[palaceNum - 1] == 0)
+                {
+                    itemLocs.Remove(pal);
+                }
+            }
         }
 
         return itemLocs;

--- a/RandomizerCore/Overworld/EastHyrule.cs
+++ b/RandomizerCore/Overworld/EastHyrule.cs
@@ -656,10 +656,6 @@ public sealed class EastHyrule : World
                     DrawRiver(props.CanWalkOnWaterWithBoots);
                 }
 
-                if (props.HiddenKasuto)
-                {
-                    RandomizeHiddenKasuto(props.ShuffleHidden);
-                }
                 if (props.HiddenPalace)
                 {
                     bool hp = RandomizeHiddenPalace(rom, props.ShuffleHidden, props.HiddenKasuto);

--- a/RandomizerCore/Overworld/EastHyrule.cs
+++ b/RandomizerCore/Overworld/EastHyrule.cs
@@ -656,6 +656,14 @@ public sealed class EastHyrule : World
                     DrawRiver(props.CanWalkOnWaterWithBoots);
                 }
 
+                if (biome == Biome.VOLCANO || biome == Biome.CANYON || biome == Biome.DRY_CANYON)
+                {
+                    bool f = MakeValleyOfDeath();
+                    if (!f)
+                    {
+                        return false;
+                    }
+                }
                 if (props.HiddenPalace)
                 {
                     bool hp = RandomizeHiddenPalace(rom, props.ShuffleHidden, props.HiddenKasuto);

--- a/RandomizerCore/RandomizerProperties.cs
+++ b/RandomizerCore/RandomizerProperties.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
 using System.Text.Json.Serialization;
 using Z2Randomizer.RandomizerCore.Overworld;
 
@@ -115,7 +116,7 @@ public class RandomizerProperties
     public bool AllowV4Rooms { get; set; }
     public bool AllowV4_4Rooms { get; set; }
     public bool HardBosses { get; set; }
-    public int PalaceItemRoomCount { get; set; }
+    public int[] PalaceItemRoomCounts { get; set; } = new int[6];
 
     //Enemies
     public bool ShuffleEnemyHP { get; set; }
@@ -326,7 +327,7 @@ public class RandomizerProperties
         minorItemCount -= MaxHearts - StartHearts - 4;
 
         //palace items other than 1 adjusts the count
-        minorItemCount += (PalaceItemRoomCount - 1) * 6;
+        minorItemCount += PalaceItemRoomCounts.Select(c => c - 1).Sum();
 
         //Start items add 1 to the count
         minorItemCount += StartCandle ? 1 : 0;

--- a/RandomizerCore/Sidescroll/ChaosPalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/ChaosPalaceGenerator.cs
@@ -24,6 +24,7 @@ internal class ChaosPalaceGenerator : PalaceGenerator
             IsRoot = true,
             // PalaceGroup = palaceGroup,
         };
+        palace.Entrance.AdjustEntrance(props.PalaceItemRoomCount, r);
         palace.AllRooms.Add(palace.Entrance);
 
         palace.BossRoom = new(roomPool.BossRooms[r.Next(roomPool.BossRooms.Count)]);

--- a/RandomizerCore/Sidescroll/ChaosPalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/ChaosPalaceGenerator.cs
@@ -24,7 +24,7 @@ internal class ChaosPalaceGenerator : PalaceGenerator
             IsRoot = true,
             // PalaceGroup = palaceGroup,
         };
-        palace.Entrance.AdjustEntrance(props.PalaceItemRoomCount, r);
+        if (palaceNumber != 7) { palace.Entrance.AdjustEntrance(props.PalaceItemRoomCounts[palaceNumber - 1], r); }
         palace.AllRooms.Add(palace.Entrance);
 
         palace.BossRoom = new(roomPool.BossRooms[r.Next(roomPool.BossRooms.Count)]);
@@ -42,7 +42,7 @@ internal class ChaosPalaceGenerator : PalaceGenerator
         if (palaceNumber < 7)
         {
             palace.ItemRooms = [];
-            for(int itemRoomNumber = 0; itemRoomNumber < props.PalaceItemRoomCount; itemRoomNumber++)
+            for(int itemRoomNumber = 0; itemRoomNumber < props.PalaceItemRoomCounts[palaceNumber - 1]; itemRoomNumber++)
             {
                 Direction itemRoomDirection;
                 Room? itemRoom = null;

--- a/RandomizerCore/Sidescroll/CoordinatePalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/CoordinatePalaceGenerator.cs
@@ -28,7 +28,7 @@ public abstract class CoordinatePalaceGenerator() : PalaceGenerator
             List<Room> itemRoomCandidates = roomPool.ItemRoomsByDirection[itemRoomDirection].ToList();
             itemRoomCandidates.FisherYatesShuffle(r);
 
-            for(int itemRoomNumber = 0; itemRoomNumber < props.PalaceItemRoomCount; itemRoomNumber++)
+            for(int itemRoomNumber = 0; itemRoomNumber < props.PalaceItemRoomCounts[palace.Number - 1]; itemRoomNumber++)
             {  
                 foreach (Room itemRoomCandidate in itemRoomCandidates)
                 {
@@ -141,7 +141,7 @@ public abstract class CoordinatePalaceGenerator() : PalaceGenerator
         if (palace.BossRoom == null
             || palace.Entrance == null
             || (palace.Number == 7 && palace.TbirdRoom == null)
-            || (palace.Number < 7 && palace.ItemRooms.Count != props.PalaceItemRoomCount))
+            || (palace.Number < 7 && palace.ItemRooms.Count != props.PalaceItemRoomCounts[palace.Number - 1]))
         {
             logger.Debug("Failed to place critical room in palace");
             return false;

--- a/RandomizerCore/Sidescroll/Palaces.cs
+++ b/RandomizerCore/Sidescroll/Palaces.cs
@@ -250,7 +250,7 @@ public class Palaces
             //If the palace doesn't have the right number of item rooms
             //or an item room is null
             //or it doesn't have a boss room when it should
-            if(palace.Number < 7 && (palace.ItemRooms.Count() != props.PalaceItemRoomCount 
+            if (palace.Number < 7 && (palace.ItemRooms.Count() != props.PalaceItemRoomCounts[palace.Number - 1]
                     || palace.ItemRooms.Any(i => i == null))
                 || palace.BossRoom == null)
             {

--- a/RandomizerCore/Sidescroll/RandomWalkCoordinatePalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/RandomWalkCoordinatePalaceGenerator.cs
@@ -22,7 +22,7 @@ public class RandomWalkCoordinatePalaceGenerator() : CoordinatePalaceGenerator()
             IsRoot = true,
             // PalaceGroup = palaceGroup
         };
-        entrance.AdjustEntrance(props.PalaceItemRoomCount, r);
+        if (palaceNumber != 7) { entrance.AdjustEntrance(props.PalaceItemRoomCounts[palaceNumber - 1], r); }
         openCoords.AddRange(entrance.GetOpenExitCoords());
         palace.AllRooms.Add(entrance);
         palace.Entrance = entrance;

--- a/RandomizerCore/Sidescroll/RandomWalkCoordinatePalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/RandomWalkCoordinatePalaceGenerator.cs
@@ -22,6 +22,7 @@ public class RandomWalkCoordinatePalaceGenerator() : CoordinatePalaceGenerator()
             IsRoot = true,
             // PalaceGroup = palaceGroup
         };
+        entrance.AdjustEntrance(props.PalaceItemRoomCount, r);
         openCoords.AddRange(entrance.GetOpenExitCoords());
         palace.AllRooms.Add(entrance);
         palace.Entrance = entrance;

--- a/RandomizerCore/Sidescroll/ReconstructedPalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/ReconstructedPalaceGenerator.cs
@@ -43,7 +43,7 @@ public class ReconstructedPalaceGenerator(CancellationToken ct) : PalaceGenerato
                     IsRoot = true,
                     // PalaceGroup = palaceGroup
                 };
-                palace.Entrance.AdjustEntrance(props.PalaceItemRoomCount, r);
+                if (palaceNumber != 7) { palace.Entrance.AdjustEntrance(props.PalaceItemRoomCounts[palaceNumber - 1], r); }
                 palace.AllRooms.Add(palace.Entrance);
 
                 palace.BossRoom = new(roomPool.BossRooms[r.Next(roomPool.BossRooms.Count)]);
@@ -55,7 +55,7 @@ public class ReconstructedPalaceGenerator(CancellationToken ct) : PalaceGenerato
 
                 if (palaceNumber < 7) //Not GP
                 {
-                    for(int i = 0; i < props.PalaceItemRoomCount; i++)
+                    for(int i = 0; i < props.PalaceItemRoomCounts[palaceNumber - 1]; i++)
                     {
                         if (roomPool.ItemRoomsByDirection.Values.Sum(i => i.Count) == 0)
                         {

--- a/RandomizerCore/Sidescroll/ReconstructedPalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/ReconstructedPalaceGenerator.cs
@@ -43,6 +43,7 @@ public class ReconstructedPalaceGenerator(CancellationToken ct) : PalaceGenerato
                     IsRoot = true,
                     // PalaceGroup = palaceGroup
                 };
+                palace.Entrance.AdjustEntrance(props.PalaceItemRoomCount, r);
                 palace.AllRooms.Add(palace.Entrance);
 
                 palace.BossRoom = new(roomPool.BossRooms[r.Next(roomPool.BossRooms.Count)]);

--- a/RandomizerCore/Sidescroll/Room.cs
+++ b/RandomizerCore/Sidescroll/Room.cs
@@ -353,7 +353,9 @@ public class Room : IJsonOnDeserialized
     {
         if (PalaceNumber == 7) { return; }
         var edit = new SideviewEditable<PalaceObject>(SideView);
+        // remove existing clouds
         edit.RemoveAll(o => o.Y < 13 && PalaceObjectExtensions.IsCloud(o));
+        // add 1 cloud per palace item room
         List<SideviewMapCommand<PalaceObject>> clouds = [];
         for (int i = 0; i < palaceItemRoomCount; i++)
         {
@@ -370,6 +372,15 @@ public class Room : IJsonOnDeserialized
             var cloud = new SideviewMapCommand<PalaceObject>(x, y, id);
             clouds.Add(cloud);
             edit.Add(cloud);
+        }
+        // also add 1 wall Iron Knuckle per palace item room
+        for (int i = 0; i < palaceItemRoomCount; i++)
+        {
+            var id = PalaceObject.IRON_KNUCKLE_STATUE;
+            int x = 42 + i;
+            int y = 2;
+            var ik = new SideviewMapCommand<PalaceObject>(x, y, id);
+            edit.Add(ik);
         }
         SideView = edit.Finalize();
     }

--- a/RandomizerCore/Sidescroll/Room.cs
+++ b/RandomizerCore/Sidescroll/Room.cs
@@ -349,6 +349,31 @@ public class Room : IJsonOnDeserialized
         }
     }
 
+    public void AdjustEntrance(int palaceItemRoomCount, Random r)
+    {
+        if (PalaceNumber == 7) { return; }
+        var edit = new SideviewEditable<PalaceObject>(SideView);
+        edit.RemoveAll(o => o.Y < 13 && PalaceObjectExtensions.IsCloud(o));
+        List<SideviewMapCommand<PalaceObject>> clouds = [];
+        for (int i = 0; i < palaceItemRoomCount; i++)
+        {
+            var id = i == 0 ? PalaceObject.LARGE_CLOUD : PalaceObject.SMALL_CLOUD_08;
+            int x, y;
+            do
+            {
+                x = r.Next(1, 8);
+            } while (clouds.Find(o => o.AbsX == x) != null);
+            do
+            {
+                y = r.Next(1, 8);
+            } while (clouds.Find(o => o.Y == y) != null);
+            var cloud = new SideviewMapCommand<PalaceObject>(x, y, id);
+            clouds.Add(cloud);
+            edit.Add(cloud);
+        }
+        SideView = edit.Finalize();
+    }
+
     public string Debug()
     {
         StringBuilder sb = new();

--- a/RandomizerCore/Sidescroll/Room.cs
+++ b/RandomizerCore/Sidescroll/Room.cs
@@ -351,7 +351,7 @@ public class Room : IJsonOnDeserialized
 
     public void AdjustEntrance(int palaceItemRoomCount, Random r)
     {
-        if (PalaceNumber == 7) { return; }
+        Debug.Assert(PalaceNumber != 7);
         var edit = new SideviewEditable<PalaceObject>(SideView);
         // remove existing clouds
         edit.RemoveAll(o => o.Y < 13 && PalaceObjectExtensions.IsCloud(o));
@@ -385,7 +385,7 @@ public class Room : IJsonOnDeserialized
         SideView = edit.Finalize();
     }
 
-    public string Debug()
+    public string DebugString()
     {
         StringBuilder sb = new();
         sb.Append("Map: " + Map + " Name: " + Name + " Sideview: ");

--- a/RandomizerCore/Sidescroll/SequentialPlacementCoordinatePalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/SequentialPlacementCoordinatePalaceGenerator.cs
@@ -44,6 +44,7 @@ public class SequentialPlacementCoordinatePalaceGenerator() : CoordinatePalaceGe
         openCoords.UnionWith(entrance.GetOpenExitCoords());
         
         allRooms= new() { { Coord.Uninitialized, entrance } };
+        entrance.AdjustEntrance(props.PalaceItemRoomCount, r);
         palace.Entrance = entrance;
 
         stallCount = 0;

--- a/RandomizerCore/Sidescroll/SequentialPlacementCoordinatePalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/SequentialPlacementCoordinatePalaceGenerator.cs
@@ -44,7 +44,7 @@ public class SequentialPlacementCoordinatePalaceGenerator() : CoordinatePalaceGe
         openCoords.UnionWith(entrance.GetOpenExitCoords());
         
         allRooms= new() { { Coord.Uninitialized, entrance } };
-        entrance.AdjustEntrance(props.PalaceItemRoomCount, r);
+        if (palaceNumber != 7) { entrance.AdjustEntrance(props.PalaceItemRoomCounts[palaceNumber - 1], r); }
         palace.Entrance = entrance;
 
         stallCount = 0;

--- a/RandomizerCore/Sidescroll/SideviewEditable.cs
+++ b/RandomizerCore/Sidescroll/SideviewEditable.cs
@@ -133,6 +133,11 @@ public class SideviewEditable<T> where T : Enum
         Commands.Remove(item);
     }
 
+    public void RemoveAll(Predicate<SideviewMapCommand<T>> match)
+    {
+        Commands.RemoveAll(match);
+    }
+
     public bool HasItem()
     {
         return Find(o => o.IsItem() && !o.Extra.IsMinorItem()) != null;

--- a/RandomizerCore/Sidescroll/SideviewEnums.cs
+++ b/RandomizerCore/Sidescroll/SideviewEnums.cs
@@ -536,6 +536,23 @@ public static class PalaceObjectExtensions
                 return false;
         }
     }
+
+    public static bool IsCloud(SideviewMapCommand<PalaceObject> command)
+    {
+        switch (command.Id)
+        {
+            case PalaceObject.LARGE_CLOUD:
+            case PalaceObject.SMALL_CLOUD_08:
+            case PalaceObject.SMALL_CLOUD_0A:
+            case PalaceObject.SMALL_CLOUD_0B:
+            case PalaceObject.SMALL_CLOUD_0C:
+            case PalaceObject.SMALL_CLOUD_0D:
+            case PalaceObject.SMALL_CLOUD_0E:
+                return true;
+            default:
+                return false;
+        }
+    }
 }
 
 public static class GreatPalaceObjectExtensions

--- a/RandomizerCore/Sidescroll/VanillaPalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/VanillaPalaceGenerator.cs
@@ -23,6 +23,7 @@ public class VanillaPalaceGenerator() : PalaceGenerator
         // var palaceGroup = Util.AsPalaceGrouping(palaceNumber);
 
         palace.Entrance = new(roomPool.Entrances.First());
+        palace.Entrance.AdjustEntrance(props.PalaceItemRoomCount, r);
         // palace.Entrance.PalaceGroup = palaceGroup;
         palace.BossRoom = new(roomPool.BossRooms.First());
         // palace.BossRoom.PalaceGroup = palaceGroup;

--- a/RandomizerCore/Sidescroll/VanillaPalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/VanillaPalaceGenerator.cs
@@ -82,6 +82,7 @@ public class VanillaPalaceGenerator() : PalaceGenerator
                 && !i.HasItem
                 //Replacing a linked room removes half of it which theoretically could work but currently breaks stuff
                 && i.LinkedRoomName == null
+                && !i.IsDropZone
                 && (i.CategorizeExits() == RoomExitType.DEADEND_EXIT_LEFT || i.CategorizeExits() == RoomExitType.DEADEND_EXIT_RIGHT)).ToList();
             //pick N-1 of them 
             IEnumerable<Room> roomsToItemRoomify = normalDeadEnds.Sample(r, props.PalaceItemRoomCount - 1);

--- a/RandomizerCore/Sidescroll/VanillaPalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/VanillaPalaceGenerator.cs
@@ -23,7 +23,6 @@ public class VanillaPalaceGenerator() : PalaceGenerator
         // var palaceGroup = Util.AsPalaceGrouping(palaceNumber);
 
         palace.Entrance = new(roomPool.Entrances.First());
-        palace.Entrance.AdjustEntrance(props.PalaceItemRoomCount, r);
         // palace.Entrance.PalaceGroup = palaceGroup;
         palace.BossRoom = new(roomPool.BossRooms.First());
         // palace.BossRoom.PalaceGroup = palaceGroup;
@@ -32,6 +31,7 @@ public class VanillaPalaceGenerator() : PalaceGenerator
 
         if (palaceNumber != 7)
         {
+            palace.Entrance.AdjustEntrance(props.PalaceItemRoomCounts[palaceNumber - 1], r);
             Room itemRoom = new(roomPool.ItemRoom!);
             palace.ItemRooms.Add(itemRoom);
             palace.AllRooms.Add(itemRoom);
@@ -65,7 +65,7 @@ public class VanillaPalaceGenerator() : PalaceGenerator
         bool removeTbird = (palaceNumber == 7 && props.RemoveTbird);
         palace.CreateTree(removeTbird);
 
-        if(palaceNumber != 7 && props.PalaceItemRoomCount == 0)
+        if(palaceNumber != 7 && props.PalaceItemRoomCounts[palaceNumber - 1] == 0)
         {
             //Replace item room with an appropriately shaped stub
             RoomExitType itemRoomExitType = roomPool.ItemRoom!.CategorizeExits();
@@ -74,7 +74,7 @@ public class VanillaPalaceGenerator() : PalaceGenerator
             palace.ItemRooms.Clear();
         }
 
-        if(palaceNumber != 7 && props.PalaceItemRoomCount > 1)
+        if(palaceNumber != 7 && props.PalaceItemRoomCounts[palaceNumber - 1] > 1)
         {
             //Find all left/right dead ends that aren't special
             List<Room> normalDeadEnds = palace.AllRooms.Where(i =>
@@ -86,7 +86,7 @@ public class VanillaPalaceGenerator() : PalaceGenerator
                 && !i.IsDropZone
                 && (i.CategorizeExits() == RoomExitType.DEADEND_EXIT_LEFT || i.CategorizeExits() == RoomExitType.DEADEND_EXIT_RIGHT)).ToList();
             //pick N-1 of them 
-            IEnumerable<Room> roomsToItemRoomify = normalDeadEnds.Sample(r, props.PalaceItemRoomCount - 1);
+            IEnumerable<Room> roomsToItemRoomify = normalDeadEnds.Sample(r, props.PalaceItemRoomCounts[palaceNumber - 1] - 1);
             //replace them with randomly selected vanilla item rooms of the same shape
             foreach(Room room in roomsToItemRoomify)
             {


### PR DESCRIPTION
For now there are clouds at the entrance + Iron Knuckles inside the walls by the elevator to indicate the number of item rooms. (Exactly how we want this to look can easily be tweaked as desired.)

The logic has been changed to handle one count per palace (1-6).

There is also a possibility for higher rolls for the larger palaces.