### PR TITLE
Add option to Allow Duplicates Of Important Items

### DIFF
--- a/CommandLine/Sample.json
+++ b/CommandLine/Sample.json
@@ -82,6 +82,7 @@
 "RandomizeKnockback": false,
 "RandomizeMusic": false,
 "RandomizeNewKasutoJarRequirements": true,
+"AllowImportantItemDuplicates": false,
 "RandomizeSpellSpellEnemy": false,
 "RemoveFlashing": true,
 "RemoveSpellItems": false,

--- a/CrossPlatformUI/BuiltinPreset.cs
+++ b/CrossPlatformUI/BuiltinPreset.cs
@@ -89,6 +89,7 @@ public static class BuiltinPreset
         ShufflePBagAmounts = false,
         PalacesContainExtraKeys = true,
         RandomizeNewKasutoJarRequirements = true,
+        AllowImportantItemDuplicates = false,
 
         //Drops
         ShuffleItemDropFrequency = true,
@@ -207,6 +208,7 @@ public static class BuiltinPreset
         ShufflePBagAmounts = false,
         PalacesContainExtraKeys = false,
         RandomizeNewKasutoJarRequirements = true,
+        AllowImportantItemDuplicates = false,
 
         //Drops
         ShuffleItemDropFrequency = true,
@@ -323,6 +325,7 @@ public static class BuiltinPreset
         ShufflePBagAmounts = true,
         PalacesContainExtraKeys = false,
         RandomizeNewKasutoJarRequirements = true,
+        AllowImportantItemDuplicates = false,
 
         //Drops
         ShuffleItemDropFrequency = true,

--- a/CrossPlatformUI/Views/Tabs/ItemsView.axaml
+++ b/CrossPlatformUI/Views/Tabs/ItemsView.axaml
@@ -47,6 +47,7 @@
           <CheckBox IsThreeState="True" IsChecked="{Binding Config.ShufflePBagAmounts}" Content="Shuffle PBag Amounts" />
           <CheckBox IsThreeState="True" IsChecked="{Binding Config.PalacesContainExtraKeys}" Content="Palaces Contain Extra Keys" />
           <CheckBox IsChecked="{Binding Config.RandomizeNewKasutoJarRequirements}" Content="Randomize New Kasuto Jar Requirements" />
+          <CheckBox IsChecked="{Binding Config.AllowImportantItemDuplicates}" Content="Allow Duplicates Of Important Items" />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/RandomizerCore/RandomizerConfiguration.cs
+++ b/RandomizerCore/RandomizerConfiguration.cs
@@ -144,6 +144,7 @@ public sealed class RandomizerConfiguration : INotifyPropertyChanged
     private bool shuffleSmallItems;
     private bool? palacesContainExtraKeys;
     private bool randomizeNewKasutoJarRequirements;
+    private bool allowImportantItemDuplicates;
     private bool? removeSpellItems;
     private bool? shufflePBagAmounts;
     private bool? includeSpellsInShuffle;
@@ -739,6 +740,12 @@ public sealed class RandomizerConfiguration : INotifyPropertyChanged
     {
         get => randomizeNewKasutoJarRequirements;
         set => SetField(ref randomizeNewKasutoJarRequirements, value);
+    }
+
+    public bool AllowImportantItemDuplicates
+    {
+        get => allowImportantItemDuplicates;
+        set => SetField(ref allowImportantItemDuplicates, value);
     }
 
     public bool? RemoveSpellItems
@@ -1832,6 +1839,7 @@ public sealed class RandomizerConfiguration : INotifyPropertyChanged
         properties.RandomizeSmallItems = ShuffleSmallItems;
         properties.ExtraKeys = PalacesContainExtraKeys ?? GetIndeterminateFlagValue(r);
         properties.RandomizeNewKasutoBasementRequirement = RandomizeNewKasutoJarRequirements;
+        properties.AllowImportantItemDuplicates = AllowImportantItemDuplicates;
         properties.PbagItemShuffle = IncludePBagCavesInItemShuffle ?? GetIndeterminateFlagValue(r);
         properties.StartWithSpellItems = RemoveSpellItems ?? GetIndeterminateFlagValue(r);
         properties.ShufflePbagXp = ShufflePBagAmounts ?? GetIndeterminateFlagValue(r);

--- a/RandomizerCore/RandomizerProperties.cs
+++ b/RandomizerCore/RandomizerProperties.cs
@@ -159,6 +159,7 @@ public class RandomizerProperties
     public bool IncludeQuestItemsInShuffle { get; set; }
     public bool RandomizeSmallItems { get; set; }
     public bool ExtraKeys { get; set; }
+    public bool AllowImportantItemDuplicates { get; set; }
     public bool RandomizeNewKasutoBasementRequirement { get; set; }
     //Include PBag caves in item shuffle
     public bool PbagItemShuffle { get; set; }


### PR DESCRIPTION
Someone suggested this at some point, as a solution for often having to 100% seeds, looking for the glove. Now that there's potentially plenty of free item locations, this feature is low hanging fruit... if we want it. Of course, it probably makes the game easier and seeds shorter.


After the normal item shuffle is done, this feature will go through the items, and make one copy of each important item, replacing minor items (like P-bags), as space allows. There will only be as many duplicates as there are minor items to replace.

What is duplicated, in order (and if they are in the pool) is: Glove, Down stab, Fairy, Thunder, Reflect, Magic key, Hammer, Raft, Flute, Jump, Upstab, Boots.


It seems to be working well. The only bug I found is with stat tracking. Stat tracking lists multiple entries of items picked up twice (with the same timestamp).