### PR TITLE
Add option to set Minimum Path To Dark Link (in number of rooms)

### DIFF
--- a/CommandLine/Sample.json
+++ b/CommandLine/Sample.json
@@ -39,6 +39,8 @@
 "GoodBoots": true,
 "GPStyle": "RECONSTRUCTED",
 "HardBosses": false,
+"PalaceItemRoomCount": "ONE",
+"DarkLinkMinDistance": "SHORT",
 "HideKasuto": false,
 "HideLessImportantLocations": true,
 "HidePalace": false,

--- a/CrossPlatformUI/BuiltinPreset.cs
+++ b/CrossPlatformUI/BuiltinPreset.cs
@@ -52,6 +52,7 @@ public static class BuiltinPreset
         BossRoomsExitType = BossRoomsExitType.OVERWORLD,
         NoDuplicateRoomsByLayout = true,
         PalaceItemRoomCount = PalaceItemRoomCount.ONE,
+        DarkLinkMinDistance = BossRoomMinDistance.SHORT,
 
         //Levels
         AttackLevelCap = 8,
@@ -160,6 +161,7 @@ public static class BuiltinPreset
         BlockingRoomsInAnyPalace = true,
         HardBosses = false,
         PalaceItemRoomCount = PalaceItemRoomCount.ONE,
+        DarkLinkMinDistance = BossRoomMinDistance.MEDIUM,
 
         //Levels
         ShuffleAttackExperience = true,
@@ -277,6 +279,7 @@ public static class BuiltinPreset
         BlockingRoomsInAnyPalace = true,
         HardBosses = true,
         PalaceItemRoomCount = PalaceItemRoomCount.ONE,
+        DarkLinkMinDistance = BossRoomMinDistance.NONE,
 
         //Levels
         ShuffleAttackExperience = true,

--- a/CrossPlatformUI/Views/Tabs/PalacesView.axaml
+++ b/CrossPlatformUI/Views/Tabs/PalacesView.axaml
@@ -24,6 +24,9 @@
                         SelectedItem="{Binding Config.GPStyle, Converter={x:Static ui:Util.EnumConvert}}" />
               <CheckBox IsThreeState="True" IsChecked="{Binding Config.ShortenGP}" Content="Shorten" />
             </StackPanel>
+            <ComboBox HorizontalAlignment="Left" Margin="0, 0" Width="300" assists:ComboBoxAssist.Label="Minimum Path To Dark Link" Theme="{StaticResource MaterialOutlineComboBox}"
+              ItemsSource="{Binding Source={x:Static rc:Enums.BossRoomMinDistanceOptions}}"
+              SelectedItem="{Binding Config.DarkLinkMinDistance, Converter={x:Static ui:Util.EnumConvert}}" />
             <ComboBox HorizontalAlignment="Left" Margin="0, 0" Width="300" assists:ComboBoxAssist.Label="Item Rooms Per Palace" Theme="{StaticResource MaterialOutlineComboBox}"
               ItemsSource="{Binding Source={x:Static rc:Enums.PalaceItemRoomCountOptions}}"
               SelectedItem="{Binding Config.PalaceItemRoomCount, Converter={x:Static ui:Util.EnumConvert}}" />

--- a/RandomizerCore/EnumTypes.cs
+++ b/RandomizerCore/EnumTypes.cs
@@ -570,6 +570,18 @@ public enum RiverDevilBlockerOption
     RANDOM
 }
 
+public enum BossRoomMinDistance
+{
+    [Description("None")]
+    NONE = 0,
+    [Description("10 rooms")]
+    SHORT = 10,
+    [Description("16 rooms")]
+    MEDIUM = 16,
+    [Description("Max")]
+    MAX = 30,
+}
+
 public enum PalaceItemRoomCount
 {
     [Description("Zero")]
@@ -617,6 +629,7 @@ public static class Enums
     public static IEnumerable<EnumDescription> LifeEffectivenessList { get; } = ToDescriptions<LifeEffectiveness>();
     public static IEnumerable<EnumDescription> XPEffectivenessList { get; } = ToDescriptions<XPEffectiveness>();
     public static IEnumerable<EnumDescription> FireOptionList { get; } = ToDescriptions<FireOption>();
+    public static IEnumerable<EnumDescription> BossRoomMinDistanceOptions { get; } = ToDescriptions<BossRoomMinDistance>();
     public static IEnumerable<EnumDescription> PalaceItemRoomCountOptions { get; } = ToDescriptions<PalaceItemRoomCount>();
     public static IEnumerable<EnumDescription> NormalPalaceStyleList { get; }
         = ToDescriptions<PalaceStyle>(i => i != PalaceStyle.RANDOM && i != PalaceStyle.RANDOM_NO_VANILLA_OR_SHUFFLE);

--- a/RandomizerCore/RandomizerConfiguration.cs
+++ b/RandomizerCore/RandomizerConfiguration.cs
@@ -105,6 +105,7 @@ public sealed class RandomizerConfiguration : INotifyPropertyChanged
     private bool reduceDripperVariance = false;
     private bool changePalacePallettes;
     private bool randomizeBossItemDrop;
+    private BossRoomMinDistance darkLinkMinDistance;
     private PalaceItemRoomCount palaceItemRoomCount;
     private int palacesToCompleteMin;
     private int palacesToCompleteMax;
@@ -494,6 +495,12 @@ public sealed class RandomizerConfiguration : INotifyPropertyChanged
     {
         get => randomizeBossItemDrop;
         set => SetField(ref randomizeBossItemDrop, value);
+    }
+
+    public BossRoomMinDistance DarkLinkMinDistance
+    {
+        get => darkLinkMinDistance;
+        set => SetField(ref darkLinkMinDistance, value);
     }
 
     public PalaceItemRoomCount PalaceItemRoomCount
@@ -1398,6 +1405,7 @@ public sealed class RandomizerConfiguration : INotifyPropertyChanged
 
             properties.ShortenGP = ShortenGP ?? GetIndeterminateFlagValue(r);
             properties.ShortenNormalPalaces = ShortenNormalPalaces ?? GetIndeterminateFlagValue(r);
+            properties.DarkLinkMinDistance = GetDarkLinkMinDistance();
 
             switch (PalaceItemRoomCount)
             {
@@ -2218,5 +2226,21 @@ public sealed class RandomizerConfiguration : INotifyPropertyChanged
         count += containerReplacementSmallItemsCount;
 
         return count;
+    }
+
+    private int GetDarkLinkMinDistance()
+    {
+        if (DarkLinkMinDistance == BossRoomMinDistance.MAX)
+        {
+            // limiting here based on how long it takes to generate the seeds
+            if (gpStyle == PalaceStyle.RECONSTRUCTED) { return 16; }
+            if (shortenGP != false) { return 20; }
+            if (gpStyle == PalaceStyle.SEQUENTIAL) { return 24; }
+            return 28;
+        }
+        else
+        {
+            return (int)DarkLinkMinDistance;
+        }
     }
 }

--- a/RandomizerCore/RandomizerProperties.cs
+++ b/RandomizerCore/RandomizerProperties.cs
@@ -101,6 +101,7 @@ public class RandomizerProperties
     public bool ShortenGP { get; set; }
     public int StartGems { get; set; }
     public bool RequireTbird { get; set; }
+    public int DarkLinkMinDistance { get; set; }
     public bool ShufflePalacePalettes { get; set; }
     public bool UpARestartsAtPalaces { get; set; }
     public bool Global5050JarDrop { get; set; }

--- a/RandomizerCore/Sidescroll/CoordinatePalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/CoordinatePalaceGenerator.cs
@@ -205,7 +205,10 @@ public abstract class CoordinatePalaceGenerator() : PalaceGenerator
         //was not a thing I felt like figuring out.
         //Maybe we use ShuffleRooms()?
         //So for now we suffer lesser performance (but still way better than Reconstructed so do we care?)
-        if (!palace.AllReachable() || (palace.Number == 7 && props.RequireTbird && !palace.RequiresThunderbird()))
+        if (!palace.AllReachable()
+            || (palace.Number == 7 && props.RequireTbird && !palace.RequiresThunderbird())
+            || (palace.Number == 7 && !palace.BossRoomMinDistance(props.DarkLinkMinDistance))
+        )
         {
             return false;
         }

--- a/RandomizerCore/Sidescroll/Palace.cs
+++ b/RandomizerCore/Sidescroll/Palace.cs
@@ -160,7 +160,7 @@ public class Palace
         roomsToCheck.Push((Entrance, Direction.WEST));
         while (roomsToCheck.Count > 0)
         {
-            var (room, originDirection) = roomsToCheck.Peek();
+            var (room, originDirection) = roomsToCheck.Pop();
             //For required thunderbird, you can't path backwards into tbird room
             if ((Number == 7 && room.IsThunderBirdRoom) 
                 || (Number < 7 && room.IsBossRoom))
@@ -170,8 +170,7 @@ public class Palace
                     return [Entrance];
                 }
             }
-            roomsToCheck.Pop();
-            
+
             // This will return false if the room is already added, so then we go to the next room to check
             if (!reachedRooms.Add(room))
             {
@@ -199,6 +198,35 @@ public class Palace
             }
         }
         return reachedRooms;
+    }
+
+    public bool BossRoomMinDistance(int minSteps)
+    {
+        if (Entrance == null) { throw new Exception("Palace Entrance is missing"); }
+        HashSet<Room> reachedRooms = [];
+        Queue<(Room, int)> roomsToCheck = [];
+        roomsToCheck.Enqueue((Entrance, 0));
+        while (roomsToCheck.Count > 0)
+        {
+            var (room, stepsToRoom) = roomsToCheck.Dequeue();
+            if (stepsToRoom >= minSteps) {
+                return true;
+            }
+            if (room.IsBossRoom)
+            {
+                return false;
+            }
+
+            // This will return false if the room is already added
+            if (!reachedRooms.Add(room)) { continue; }
+
+            int stepsToNextRoom = stepsToRoom + 1;
+            if (room.Left != null) { roomsToCheck.Enqueue((room.Left, stepsToNextRoom)); }
+            if (room.Right != null) { roomsToCheck.Enqueue((room.Right, stepsToNextRoom)); }
+            if (room.Up != null) { roomsToCheck.Enqueue((room.Up, stepsToNextRoom)); }
+            if (room.Down != null) { roomsToCheck.Enqueue((room.Down, stepsToNextRoom)); }
+        }
+        return false; // Boss room not found??
     }
 
     public bool AllReachable(bool allowBacktracking = false)

--- a/RandomizerCore/Sidescroll/ReconstructedPalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/ReconstructedPalaceGenerator.cs
@@ -236,9 +236,12 @@ public class ReconstructedPalaceGenerator(CancellationToken ct) : PalaceGenerato
                 logger.Debug("Palace room shuffle attempt #" + tries);
             }
             while (
-            (!reachable || (palaceNumber == 7 && props.RequireTbird && !palace.RequiresThunderbird()) || palace.HasDeadEnd())
-            && (tries < ROOM_SHUFFLE_ATTEMPT_LIMIT)
-                );
+                (!reachable
+                 || (palaceNumber == 7 && props.RequireTbird && !palace.RequiresThunderbird())
+                 || (palaceNumber == 7 && !palace.BossRoomMinDistance(props.DarkLinkMinDistance))
+                 || palace.HasDeadEnd()
+                ) && (tries < ROOM_SHUFFLE_ATTEMPT_LIMIT)
+            );
         } while (tries >= ROOM_SHUFFLE_ATTEMPT_LIMIT);
         palace.Generations += tries;
         palace.IsValid = true;

--- a/RandomizerCore/Sidescroll/VanillaShufflePalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/VanillaShufflePalaceGenerator.cs
@@ -15,7 +15,8 @@ public class VanillaShufflePalaceGenerator() : VanillaPalaceGenerator()
         int tries = 0;
         while (
             !palace.AllReachable() 
-            || (palaceNumber == 7 && props.RequireTbird && !palace.RequiresThunderbird()) 
+            || (palaceNumber == 7 && props.RequireTbird && !palace.RequiresThunderbird())
+            || (palaceNumber == 7 && !palace.BossRoomMinDistance(props.DarkLinkMinDistance))
             || palace.HasDeadEnd()
         )
         {


### PR DESCRIPTION
This is proposed as a solution to the anticlimactic, very short GP's that sometimes happen.

How it works is it calculates the shortest path to Dark Link and invalidates the palace if it is shorter than the selected option. This adds some seed generation time, but not too much (plus it's optional.)