### PR TITLE
Update project to try to prevent Anti-Virus triggers

### DIFF
--- a/CrossPlatformUI.Desktop/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/CrossPlatformUI.Desktop/Properties/PublishProfiles/FolderProfile.pubxml
@@ -5,7 +5,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
 <Project>
   <PropertyGroup>
     <Configuration>Release</Configuration>
-    <Platform>x64</Platform>
+    <Platform>Any CPU</Platform>
     <PublishDir>bin\Release\net8.0\publish\win-x64\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <_TargetId>Folder</_TargetId>

--- a/CrossPlatformUI/CrossPlatformUI.csproj
+++ b/CrossPlatformUI/CrossPlatformUI.csproj
@@ -22,10 +22,10 @@
         <PackageReference Include="Avalonia.ReactiveUI" Version="$(AvaloniaVersion)" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
         <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
-        <PackageReference Include="DialogHost.Avalonia" Version="0.8.0-avalonia11dot1-1" />
-        <PackageReference Include="Material.Avalonia" Version="3.6.0" />
-        <PackageReference Include="Material.Icons.Avalonia" Version="2.1.9" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0-preview.3.24172.9" />
+        <PackageReference Include="DialogHost.Avalonia" Version="$(DialogHostAvaloniaVersion)" />
+        <PackageReference Include="Material.Avalonia" Version="$(MaterialAvaloniaVersion)" />
+        <PackageReference Include="Material.Icons.Avalonia" Version="$(MaterialIconsAvaloniaVersion)" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
         <PackageReference Include="ReactiveUI.Validation" Version="3.1.7" />
         <PackageReference Include="Aigamo.ResXGenerator" Version="4.2.0">
             <PrivateAssets>all</PrivateAssets>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,11 @@
 <Project>
   <PropertyGroup>
     <Nullable>enable</Nullable>
-    <AvaloniaVersion>11.2.4</AvaloniaVersion>
+    <AvaloniaVersion>11.3.4</AvaloniaVersion>
+    <DialogHostAvaloniaVersion>0.9.3</DialogHostAvaloniaVersion>
+    <MaterialAvaloniaVersion>3.13.0</MaterialAvaloniaVersion>
+    <MaterialIconsAvaloniaVersion>2.1.12</MaterialIconsAvaloniaVersion>
+    <SkiaSharpVersion>2.88.9</SkiaSharpVersion> <!-- Match version used by Avalonia internally -->
 <!--    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>-->
     <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,10 +9,15 @@
 <!--    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>-->
     <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableWorkloadRestore>true</EnableWorkloadRestore>
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
 
     <PublishTrimmed>false</PublishTrimmed>
 <!--    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>-->
 <!--    <PublishTrimmed>true</PublishTrimmed>-->
-  </PropertyGroup>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Workload Include="wasm-tools" />
+    </ItemGroup>
 </Project>

--- a/RandomizerCore/Music/Readme.txt
+++ b/RandomizerCore/Music/Readme.txt
@@ -1,1 +1,0 @@
-TODO: Add a link to the wiki instrucations.

--- a/RandomizerCore/RandomizerCore.csproj
+++ b/RandomizerCore/RandomizerCore.csproj
@@ -2,37 +2,16 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <UpdateUrl>https://sites.google.com/site/z2randomizer/</UpdateUrl>
-    <PublisherName>Doug Shook</PublisherName>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>0.9.0.0</ApplicationVersion>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <PublishWizardCompleted>true</PublishWizardCompleted>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>false</UseWindowsForms>
     <Platforms>AnyCPU;x64</Platforms>
     <Nullable>enable</Nullable>
     <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-    <ManifestCertificateThumbprint>22CC5DF6B2071FFA83917B5AAC93AE355BED01D9</ManifestCertificateThumbprint>
-    <ManifestKeyFile>Z2Randomizer_1_TemporaryKey.pfx</ManifestKeyFile>
-    <GenerateManifests>true</GenerateManifests>
-    <SignManifests>false</SignManifests>
-    <Version>4.4.8</Version>
     <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <RootNamespace>Z2Randomizer.RandomizerCore</RootNamespace>
   </PropertyGroup>
+
   <ItemGroup>
     <None Remove="Asm\DashSpell.s" />
     <None Remove="Asm\ExpandedPauseMenu.s" />
@@ -45,43 +24,42 @@
     <None Remove="Asm\MMC5.s" />
     <None Remove="Asm\z2r.inc" />
     <None Remove="Asm\z2rndft.ips" />
+
+    <None Update="Music\README.txt" CopyToOutputDirectory="PreserveNewest" />
+
     <None Update="Sprites\*.ips" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
+
   <ItemGroup>
     <Content Include="nlog.config" CopyToOutputDirectory="Always" />
-    <Content Include="*.json">
+    <Content Include="PalaceRooms.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
     </Content>
     <Content Include="js65\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="js65.interop" Version="1.0.0-alpha3" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-x64" Version="7.4.5" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.osx-arm64" Version="7.4.5" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.4.5" />
-    <PackageReference Include="ReactiveUI" Version="20.1.1" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-x64" Version="7.4.5" Condition="$([MSBuild]::IsOsPlatform('Linux'))" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.osx-arm64" Version="7.4.5" Condition="$([MSBuild]::IsOsPlatform('OSX'))" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.4.5" Condition="$([MSBuild]::IsOsPlatform('Windows'))" />
+    <PackageReference Include="ReactiveUI" Version="20.4.1" />
     <PackageReference Include="ReactiveUI.SourceGenerators" Version="2.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="SD.Tools.Algorithmia" Version="1.4.0" />
-    <PackageReference Include="NLog" Version="5.2.6" />
+    <PackageReference Include="NLog" Version="6.0.3" />
+    <ProjectReference Include="..\FtRandoLib\FtRandoLib.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Include="Asm\*.s" />
     <EmbeddedResource Include="Asm\Graphics\item_sprites.chr" />
     <EmbeddedResource Include="Asm\Graphics\randomizer_text.chr" />
     <EmbeddedResource Include="Asm\z2r.inc" />
     <EmbeddedResource Include="Asm\z2rndft.ips" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\FtRandoLib\FtRandoLib.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="Music\README.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Remove old RandomizerCore.csproj manifest stuff that may trigger something
- Update dependency versions
- Building for "Any CPU" instead of x64 seems to fix the Anti-Virus trigger

- Now only copying PalaceRooms.json (and not CustomRooms.json or package.json)
- Runtimes for other platforms should not be included now (this should probably half the install size).

(The program still runs fine for me. New DialogHost looks better.)