### PR TITLE
Fix custom music

### DIFF
--- a/RandomizerCore/Asm/MMC5.s
+++ b/RandomizerCore/Asm/MMC5.s
@@ -609,11 +609,11 @@ UPDATE_REFS SwapToPRG0 @ $C1CA $C1CE $C256 $C350 $C636 $C68B $C9EF $CCFA $D0FD $
 UPDATE_REFS SwapToPRG0 @ $DFD9 $DFE2 $DFF6 $DFFF $E017 $E022 $E02B $E077 $E1E4 $FF4A
 
 ; z2ft uses this location
-.if !ENABLE_Z2FT
+;.if !ENABLE_Z2FT
 
 UPDATE_REFS SwapToSavedPRG @ $E002
 
-.endif
+;.endif
 
 .segment "PRG0"
 

--- a/RandomizerCore/Asm/z2ft.s
+++ b/RandomizerCore/Asm/z2ft.s
@@ -3,68 +3,10 @@
 .import SwapPRG, SwapToSavedPRG, SwapToPRG0
 .export UpdateSound
 
-; Screen split IRQ implementation. This is not technically a part of z2ft, but due to the policy of not making the game faster than vanilla, this optimization is only enabled when z2ft is enabled to partially offset the cost of FT playback.
-
 ; Game variables/locations
 UpdateSound = $878c
 
 .segment "PRG7"
-
-; Replace the code to wait for sprite 0 with code to set up the scanline IRQ
-;.org $d4b2
-;	; Can clobber all registers
-;	lda PpuCtrlShadow
-;	ora $746 ; Have concerns about this
-;	;sta PpuCtrlShadow
-;	sta PpuCtrlForIrq
-;	lda ScrollPosShadow
-;	sta ScrollPosForIrq
-;
-;	lda $200
-;	clc
-;	adc #$11
-;	sta LineIrqTgtReg
-;
-;	lda #ENABLE_SCANLINE_IRQ
-;	sta LineIrqStatusReg
-;
-;	cli
-;
-;	; Exact fit
-
-.reloc
-
-;.proc IrqHdlr
-;	; $22 bytes
-;	pha
-;	txa
-;	pha
-;
-;	lda LineIrqStatusReg
-;	;lda #DISABLE_SCANLINE_IRQ
-;	;sta LineIrqStatusReg
-;
-;	ldx PpuCtrlForIrq
-;	lda ScrollPosForIrq
-;	sta PPUSCROLL
-;	lda #$0
-;	sta PPUSCROLL
-;	stx PPUCTRL
-;
-;	stx PpuCtrlShadow ; Not sure about this
-;
-;	pla
-;	tax
-;	pla
-;
-;	rti
-;.endproc ; IrqHdlr
-;
-;.org $fffe
-;	.word IrqHdlr
-
-;.org $c1a8
-;	jsr CallUpdateSound
 
 .reloc
 
@@ -88,13 +30,6 @@ UpdateSound = $878c
 	pla
 	sta NmiBankShadow8
 	sta PrgBank8Reg
-
-	; Copy what was overwritten from original game
-;	lda PPUSTATUS
-
-	; Copy what was overwritten from Z2R's HUD fixes
-;	clc
-;	ror $f4
 
 	rts
 .endproc ; CallUpdateSound

--- a/RandomizerCore/Asm/z2ft.s
+++ b/RandomizerCore/Asm/z2ft.s
@@ -1,6 +1,6 @@
 .include "z2r.inc"
 
-.import SwapPRG, SwapToSavedPRG, SwapToPRG0, NmiBankShadow8, NmiBankShadowA
+.import SwapPRG, SwapToSavedPRG, SwapToPRG0
 .export UpdateSound
 
 ; Screen split IRQ implementation. This is not technically a part of z2ft, but due to the policy of not making the game faster than vanilla, this optimization is only enabled when z2ft is enabled to partially offset the cost of FT playback.
@@ -8,73 +8,67 @@
 ; Game variables/locations
 UpdateSound = $878c
 
-PpuCtrlShadow = $ff
-ScrollPosShadow = $fd
-
-; These are new variables that use free memory
-PpuCtrlForIrq = $6c7
-ScrollPosForIrq = $6c8
-
 .segment "PRG7"
 
 ; Replace the code to wait for sprite 0 with code to set up the scanline IRQ
-.org $d4b2
-	; Can clobber all registers
-	lda PpuCtrlShadow
-	ora $746 ; Have concerns about this
-	;sta PpuCtrlShadow
-	sta PpuCtrlForIrq
-	lda ScrollPosShadow
-	sta ScrollPosForIrq
-	
-	lda $200
-	clc
-	adc #$11
-	sta LineIrqTgtReg
-	
-	lda #ENABLE_SCANLINE_IRQ
-	sta LineIrqStatusReg
-	
-	cli
-
-	; Exact fit
-
-.reloc
-
-.proc IrqHdlr
-	; $22 bytes
-	pha
-	txa
-	pha
-	
-	lda LineIrqStatusReg
-	;lda #DISABLE_SCANLINE_IRQ
-	;sta LineIrqStatusReg
-	
-	ldx PpuCtrlForIrq
-	lda ScrollPosForIrq
-	sta PPUSCROLL
-	lda #$0
-	sta PPUSCROLL
-	stx PPUCTRL
-	
-	stx PpuCtrlShadow ; Not sure about this
-	
-	pla
-	tax
-	pla
-	
-	rti
-.endproc ; IrqHdlr
-
-.org $fffe
-	.word IrqHdlr
-
-.org $c1a8
-	jsr CallUpdateSound
+;.org $d4b2
+;	; Can clobber all registers
+;	lda PpuCtrlShadow
+;	ora $746 ; Have concerns about this
+;	;sta PpuCtrlShadow
+;	sta PpuCtrlForIrq
+;	lda ScrollPosShadow
+;	sta ScrollPosForIrq
+;
+;	lda $200
+;	clc
+;	adc #$11
+;	sta LineIrqTgtReg
+;
+;	lda #ENABLE_SCANLINE_IRQ
+;	sta LineIrqStatusReg
+;
+;	cli
+;
+;	; Exact fit
 
 .reloc
 
+;.proc IrqHdlr
+;	; $22 bytes
+;	pha
+;	txa
+;	pha
+;
+;	lda LineIrqStatusReg
+;	;lda #DISABLE_SCANLINE_IRQ
+;	;sta LineIrqStatusReg
+;
+;	ldx PpuCtrlForIrq
+;	lda ScrollPosForIrq
+;	sta PPUSCROLL
+;	lda #$0
+;	sta PPUSCROLL
+;	stx PPUCTRL
+;
+;	stx PpuCtrlShadow ; Not sure about this
+;
+;	pla
+;	tax
+;	pla
+;
+;	rti
+;.endproc ; IrqHdlr
+;
+;.org $fffe
+;	.word IrqHdlr
+
+;.org $c1a8
+;	jsr CallUpdateSound
+
+.reloc
+
+.export CallUpdateSound
 .proc CallUpdateSound
 	; Must preserve these because in Z2R it's possible to be interrupted by NMI that may change banks.
 	lda NmiBankShadow8
@@ -82,7 +76,7 @@ ScrollPosForIrq = $6c8
 	lda NmiBankShadowA
 	pha
 
-	lda #$6
+	lda #6
 
 	jsr SwapPRG
 
@@ -96,19 +90,19 @@ ScrollPosForIrq = $6c8
 	sta PrgBank8Reg
 
 	; Copy what was overwritten from original game
-	lda PPUSTATUS
+;	lda PPUSTATUS
 
 	; Copy what was overwritten from Z2R's HUD fixes
-	clc
-	ror $f4
+;	clc
+;	ror $f4
 
 	rts
 .endproc ; CallUpdateSound
 
 ; Do NOT call UpdateSound from overworld loading code as Z2R enables NMI during loading so UpdateSound will be called anyway.
-;.org $c1bf
-;	rts
-;	nop
+.org $c1bf
+	rts
+	nop
 
 ; Get rid of original call to UpdateSound to move it after setting up IRQ
 UPDATE_REFS SwapToPRG0 @ $c130

--- a/RandomizerCore/Asm/z2r.inc
+++ b/RandomizerCore/Asm/z2r.inc
@@ -188,12 +188,16 @@ RESV DripperRedCounter
 ; just hardcode the stats only to one file.
 StatTrackingSaveFileClear = $7401
 
+.export NmiBankShadow8, NmiBankShadowA
+; Reserve these in SRAM to prevent issues when clearing ram
+NmiBankShadow8 = $6380
+NmiBankShadowA = $6381
+SoftDisableNmi = $6382
+
+StatTrackingBase = $6383
+SET_RES_BASE StatTrackingBase
 
 ;; The follow stats are NOT checkpointed because they persist between reloads
-
-
-StatTrackingBase = $6380
-SET_RES_BASE StatTrackingBase
 
 ; All Timestamp types listed below for reference
 TS_COUNT .set 0
@@ -258,12 +262,6 @@ CHECKPOINT_LEN = RES_OFFSET - CHECKPOINT_START
 ; Duplicate the timestamp memory here that we'll copy after saving
 RESV Checkpoint, CHECKPOINT_LEN
 STAT_TRACKING_SIZE = RES_OFFSET
-
-.export NmiBankShadow8, NmiBankShadowA
-; Reserve these in SRAM to prevent issues when clearing ram
-RESV NmiBankShadow8, 1
-RESV NmiBankShadowA, 1
-RESV SoftDisableNmi, 1
 
 ; Reserve 256 bytes to store a sideview buffer.
 ; The sideview loading code is patched to quickly bank switch to the extended banks for palace data,

--- a/RandomizerCore/RandomizerConfiguration.cs
+++ b/RandomizerCore/RandomizerConfiguration.cs
@@ -629,6 +629,7 @@ public sealed partial class RandomizerConfiguration : ReactiveObject
         UseCustomRooms = false;
         DisableHUDLag = false;
         this.WhenAnyPropertyChanged()
+            .ObserveOn(RxApp.MainThreadScheduler)
             .Throttle(TimeSpan.FromMilliseconds(10))
             .Select(_ => Serialize())
             .ToProperty(this, nameof(Flags));

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This might conflict with https://github.com/Ellendar/Z2Randomizer/pull/306 so if it does, merge that first and i'll rebase after.

Fixes custom music support in 4.4 by removing some of the code that was duplicated when redoing the MMC5 conversion.