### PR TITLE
Fix stale save data from unregistered save slots being kept

### DIFF
--- a/RandomizerCore/Hyrule.cs
+++ b/RandomizerCore/Hyrule.cs
@@ -4097,6 +4097,7 @@ EndTileComparisons = $8601
         
         RandomizeStartingValues(engine, rom);
         rom.FixRebonackHorseKillBug();
+        rom.FixStaleSaveSlotData(engine);
         rom.UseExtendedBanksForPalaceRooms(engine);
         rom.ExtendMapSize(engine);
         ExpandedPauseMenu(engine);


### PR DESCRIPTION
I don't know if we want to merge this before 5.0. I'm fine with waiting for 5.0.1.