### PR TITLE
Add a global behavior for scrolling comboboxes

### DIFF
--- a/CrossPlatformUI/App.axaml
+++ b/CrossPlatformUI/App.axaml
@@ -6,6 +6,7 @@
              xmlns:dialogHostAvalonia="clr-namespace:DialogHostAvalonia;assembly=DialogHost.Avalonia"
              xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              xmlns:assists="clr-namespace:Material.Styles.Assists;assembly=Material.Styles"
+             xmlns:behaviors="clr-namespace:CrossPlatformUI.Behaviors"
              x:Class="CrossPlatformUI.App"
              RequestedThemeVariant="Default">
              <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
@@ -48,6 +49,17 @@
                         " />
                 <Setter Property="Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(assists:SelectionControlAssist.InnerForeground)}" />
             </Style>
+        </Style>
+        
+        <!-- Add a default behavior to all of the comboboxes to let the scroll with the mouse wheel -->
+        <Style Selector="ComboBox">
+            <Setter Property="(Interaction.Behaviors)">
+                <BehaviorCollectionTemplate>
+                    <BehaviorCollection>
+                        <behaviors:ScrollSelectBehavior />
+                    </BehaviorCollection>
+                </BehaviorCollectionTemplate>
+            </Setter>
         </Style>
     </Application.Styles>
   <Application.Resources>

--- a/CrossPlatformUI/Behaviors/ScrollSelectBehavior.cs
+++ b/CrossPlatformUI/Behaviors/ScrollSelectBehavior.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Xaml.Interactivity;
+
+namespace CrossPlatformUI.Behaviors;
+
+public class ScrollSelectBehavior : Behavior<ComboBox>
+{
+    // Accumulated delta for smooth / throttled scrolling
+    private double _scrollAccumulator = 0;
+    
+    /// <summary>
+    /// Whether to use natural scrolling (like macOS). Defaults to true on macOS.
+    /// </summary>
+    public static readonly StyledProperty<bool> UseNaturalScrollProperty =
+        AvaloniaProperty.Register<ScrollSelectBehavior, bool>(nameof(UseNaturalScroll));
+    public bool UseNaturalScroll
+    {
+        get => GetValue(UseNaturalScrollProperty);
+        set => SetValue(UseNaturalScrollProperty, value);
+    }
+
+    /// <summary>
+    /// How much scroll must accumulate before we move one item
+    /// </summary>
+    public static readonly StyledProperty<double> ScrollThresholdProperty =
+        AvaloniaProperty.Register<ScrollSelectBehavior, double>(nameof(ScrollThreshold), 1.0);
+
+    public double ScrollThreshold
+    {
+        get => GetValue(ScrollThresholdProperty);
+        set => SetValue(ScrollThresholdProperty, value);
+    }
+
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+
+        // Default to natural scroll on macOS
+        if (OperatingSystem.IsMacOS() && !IsSet(UseNaturalScrollProperty))
+            UseNaturalScroll = true;
+
+        AssociatedObject?.AddHandler(InputElement.PointerWheelChangedEvent, OnPointerWheelChanged, RoutingStrategies.Tunnel);
+    }
+
+    protected override void OnDetaching()
+    {
+        AssociatedObject?.RemoveHandler(InputElement.PointerWheelChangedEvent, OnPointerWheelChanged);
+        base.OnDetaching();
+    }
+
+    // Scroll through the list of items when rolling the mousewheel over an element.
+    private void OnPointerWheelChanged(object? sender, PointerWheelEventArgs e)
+    {
+        if (AssociatedObject?.Items is not IEnumerable itemsEnum)
+            return;
+
+        var items = itemsEnum.Cast<object>().ToList();
+        if (items.Count == 0)
+            return;
+
+        // Adjust for natural scroll direction
+        var delta = UseNaturalScroll ? -e.Delta.Y : e.Delta.Y;
+
+        // Accumulate the delta
+        _scrollAccumulator += delta;
+
+        // Only move when we exceed threshold
+        if (Math.Abs(_scrollAccumulator) >= ScrollThreshold)
+        {
+            int stepCount = (int)Math.Floor(Math.Abs(_scrollAccumulator) / ScrollThreshold);
+            int direction = Math.Sign(_scrollAccumulator);
+
+            var newIndex = AssociatedObject.SelectedIndex - (direction * stepCount);
+
+            // Clamp to valid range
+            newIndex = Math.Clamp(newIndex, 0, items.Count - 1);
+
+            AssociatedObject.SelectedIndex = newIndex;
+
+            // Retain leftover delta (for smoothness)
+            _scrollAccumulator %= ScrollThreshold;
+        }
+
+        e.Handled = true;
+    }
+}


### PR DESCRIPTION
This bring behavior back in line with the OG winforms app. Now you can hover a combobox and scroll the mouse wheel to change a setting without clicking it