### PR TITLE
Add option to remove less important overworld locations

### DIFF
--- a/CrossPlatformUI/Lang/Resources.resx
+++ b/CrossPlatformUI/Lang/Resources.resx
@@ -504,11 +504,21 @@ cabin similar to vanilla.
 If disabled, Bagu&apos;s cabin is an isolated forest tile surrounded on all sides by other
 terrain.</value>
 	</data>
-	<data name="HideLessImportantLocationsToolTip" xml:space="preserve">
-<value>If enabled, locations that only contain minor items or have no value will be hidden within
-more of the same terrain.
+	<data name="LessImportantLocationsToolTip" xml:space="preserve">
+<value>How to handle overworld tiles that contain minor things like red jars, fairies or P-bags.
 
-If disabled, all such tiles will be surrounded on all sides by other terrain.</value>
+Blend In:
+These tiles will be hidden among other tiles of the same terrain.
+
+Isolate:
+These tiles will be surrounded on all sides by other terrain, just like major item
+location tiles.
+
+Remove:
+Remove these tiles from the game.
+
+Random:
+Pick one of the above at random.</value>
 	</data>
 	<data name="AllWaterIsWalkableWithBootsToolTip" xml:space="preserve">
 <value>If enabled, all water tiles can be walked on with boots. If unselected, the only walkable

--- a/CrossPlatformUI/Presets/BeginnerPreset.cs
+++ b/CrossPlatformUI/Presets/BeginnerPreset.cs
@@ -29,7 +29,7 @@ public static class BeginnerPreset
         RiverDevilBlockerOption = RiverDevilBlockerOption.PATH,
         EastRocks = false,
         GenerateBaguWoods = false,
-        HideLessImportantLocations = true,
+        LessImportantLocationsOption = LessImportantLocationsOption.HIDE,
         RestrictConnectionCaveShuffle = true,
         AllowConnectionCavesToBeBlocked = false,
         GoodBoots = true,

--- a/CrossPlatformUI/Presets/FullShufflePreset.cs
+++ b/CrossPlatformUI/Presets/FullShufflePreset.cs
@@ -28,7 +28,7 @@ public static class FullShufflePreset
         RiverDevilBlockerOption = RiverDevilBlockerOption.RANDOM,
         EastRocks = true,
         GenerateBaguWoods = false,
-        HideLessImportantLocations = true,
+        LessImportantLocationsOption = LessImportantLocationsOption.HIDE,
         RestrictConnectionCaveShuffle = true,
         AllowConnectionCavesToBeBlocked = true,
         GoodBoots = true,

--- a/CrossPlatformUI/Presets/HardmodePreset.cs
+++ b/CrossPlatformUI/Presets/HardmodePreset.cs
@@ -30,7 +30,7 @@ public static class HardmodePreset
         RiverDevilBlockerOption = RiverDevilBlockerOption.RANDOM,
         EastRocks = true,
         GenerateBaguWoods = true,
-        HideLessImportantLocations = true,
+        LessImportantLocationsOption = LessImportantLocationsOption.REMOVE,
         RestrictConnectionCaveShuffle = true,
         AllowConnectionCavesToBeBlocked = true,
         GoodBoots = true,

--- a/CrossPlatformUI/Presets/MaxRandoPreset.cs
+++ b/CrossPlatformUI/Presets/MaxRandoPreset.cs
@@ -27,7 +27,7 @@ public static class MaxRandoPreset
         RiverDevilBlockerOption = RiverDevilBlockerOption.RANDOM,
         EastRocks = true,
         GenerateBaguWoods = true,
-        HideLessImportantLocations = true,
+        LessImportantLocationsOption = LessImportantLocationsOption.HIDE,
         RestrictConnectionCaveShuffle = true,
         AllowConnectionCavesToBeBlocked = true,
         GoodBoots = true,

--- a/CrossPlatformUI/Presets/NormalPreset.cs
+++ b/CrossPlatformUI/Presets/NormalPreset.cs
@@ -28,7 +28,7 @@ public static class NormalPreset
         RiverDevilBlockerOption = RiverDevilBlockerOption.RANDOM,
         EastRocks = true,
         GenerateBaguWoods = false,
-        HideLessImportantLocations = true,
+        LessImportantLocationsOption = LessImportantLocationsOption.REMOVE,
         RestrictConnectionCaveShuffle = true,
         AllowConnectionCavesToBeBlocked = true,
         GoodBoots = true,

--- a/CrossPlatformUI/Presets/RandomPercentPreset.cs
+++ b/CrossPlatformUI/Presets/RandomPercentPreset.cs
@@ -27,7 +27,7 @@ public static class RandomPercentPreset
         RiverDevilBlockerOption = RiverDevilBlockerOption.RANDOM,
         EastRocks = null,
         GenerateBaguWoods = null,
-        HideLessImportantLocations = null,
+        LessImportantLocationsOption = LessImportantLocationsOption.RANDOM,
         RestrictConnectionCaveShuffle = null,
         AllowConnectionCavesToBeBlocked = true,
         GoodBoots = null,

--- a/CrossPlatformUI/Presets/StandardPreset.cs
+++ b/CrossPlatformUI/Presets/StandardPreset.cs
@@ -28,7 +28,7 @@ public static class StandardPreset
         RiverDevilBlockerOption = RiverDevilBlockerOption.PATH,
         EastRocks = false,
         GenerateBaguWoods = true,
-        HideLessImportantLocations = true,
+        LessImportantLocationsOption = LessImportantLocationsOption.HIDE,
         RestrictConnectionCaveShuffle = true,
         AllowConnectionCavesToBeBlocked = true,
         GoodBoots = true,

--- a/CrossPlatformUI/Presets/UpstartsTournamentPreset.cs
+++ b/CrossPlatformUI/Presets/UpstartsTournamentPreset.cs
@@ -27,7 +27,7 @@ public static class UpstartsTournamentPreset
         EncounterRate = EncounterRate.HALF,
         EastRocks = false,
         GenerateBaguWoods = true,
-        HideLessImportantLocations = true,
+        LessImportantLocationsOption = LessImportantLocationsOption.HIDE,
         RestrictConnectionCaveShuffle = true,
         AllowConnectionCavesToBeBlocked = true,
         GoodBoots = true,

--- a/CrossPlatformUI/Views/Tabs/OverworldView.axaml
+++ b/CrossPlatformUI/Views/Tabs/OverworldView.axaml
@@ -96,13 +96,14 @@
             >
                 <ToolTip.Tip><TextBlock Text="{x:Static lang:Resources.GenerateBagusWoodsToolTip}"/></ToolTip.Tip>
             </CheckBox>
-            <CheckBox
-                IsThreeState="True"
-                IsChecked="{Binding Config.HideLessImportantLocations}"
-                Content="Hide Less Important Locations"
+            <ComboBox
+                Grid.Row="0" Grid.Column="0" Theme="{StaticResource MaterialOutlineComboBox}"
+                assists:ComboBoxAssist.Label="Less Important Locations"
+                ItemsSource="{Binding Source={x:Static rc:Enums.LessImportantLocationsOptionList}}"
+                SelectedItem="{Binding Config.LessImportantLocationsOption, Converter={x:Static ui:Util.EnumConvert}}"
             >
-                <ToolTip.Tip><TextBlock Text="{x:Static lang:Resources.HideLessImportantLocationsToolTip}"/></ToolTip.Tip>
-            </CheckBox>
+                <ToolTip.Tip><TextBlock Text="{x:Static lang:Resources.LessImportantLocationsToolTip}"/></ToolTip.Tip>
+            </ComboBox>
         </StackPanel>
         <StackPanel Grid.Column="1">
             <CheckBox

--- a/RandomizerCore/EnumTypes.cs
+++ b/RandomizerCore/EnumTypes.cs
@@ -595,6 +595,19 @@ public enum IndeterminateOptionRate
     NINETY_PERCENT
 }
 
+[DefaultValue(HIDE)]
+public enum LessImportantLocationsOption
+{
+    [Description("Blend In")]
+    HIDE,
+    [Description("Isolate")]
+    ISOLATE,
+    [Description("Remove")]
+    REMOVE,
+    [Description("Random")]
+    RANDOM,
+}
+
 [DefaultValue(PATH)]
 public enum RiverDevilBlockerOption
 {
@@ -682,6 +695,8 @@ public static class Enums
     public static IEnumerable<EnumDescription> MazeBiomeList { get; } = ToDescriptions<Biome>(i => i.IsMazeBiome());
     public static IEnumerable<EnumDescription> DMBiomeList { get; } = ToDescriptions<Biome>(i => i.IsDMBiome());
     public static IEnumerable<EnumDescription> ContinentConnectionTypeList { get; } = ToDescriptions<ContinentConnectionType>();
+    public static IEnumerable<EnumDescription> LessImportantLocationsOptionList { get; } = ToDescriptions<LessImportantLocationsOption>();
+
     public static IEnumerable<EnumDescription> EncounterRateList { get; } = ToDescriptions<EncounterRate>();
     public static IEnumerable<EnumDescription> CharacterColorList { get; } = ToDescriptions<NesColor>();
     public static IEnumerable<EnumDescription> BeamSpritesList { get; } = ToDescriptions<BeamSprites>();

--- a/RandomizerCore/Overworld/EastHyrule.cs
+++ b/RandomizerCore/Overworld/EastHyrule.cs
@@ -320,7 +320,7 @@ public sealed class EastHyrule : World
                 location.TerrainType = terrains[location.MemAddress];
             }
         }
-        if (props.HideLessImportantLocations)
+        if (props.LessImportantLocationsOption != LessImportantLocationsOption.ISOLATE)
         {
             unimportantLocs =
             [
@@ -481,7 +481,7 @@ public sealed class EastHyrule : World
                         location.TerrainType = terrains[location.MemAddress];
                     }
                 }
-                if (props.HideLessImportantLocations)
+                if (props.LessImportantLocationsOption != LessImportantLocationsOption.ISOLATE)
                 {
                     unimportantLocs = new List<Location>
                     {
@@ -764,7 +764,7 @@ public sealed class EastHyrule : World
 
                 bool riverDevil = props.RiverDevilBlockerOption == RiverDevilBlockerOption.CAVE;
                 bool rockBlock = props.EastRocks && !props.EastRockIsPath;
-                PlaceHiddenLocations();
+                PlaceHiddenLocations(props.LessImportantLocationsOption);
                 BlockCaves(props.BoulderBlockConnections, riverDevil, rockBlock, hiddenPalaceLocation, hiddenKasutoLocation);
                 riverDevil = props.RiverDevilBlockerOption == RiverDevilBlockerOption.PATH;
                 rockBlock = props.EastRocks && props.EastRockIsPath;

--- a/RandomizerCore/Overworld/WestHyrule.cs
+++ b/RandomizerCore/Overworld/WestHyrule.cs
@@ -265,7 +265,7 @@ public sealed class WestHyrule : World
 
         walkableTerrains = new List<Terrain>() { Terrain.DESERT, Terrain.GRASS, Terrain.FOREST, Terrain.SWAMP, Terrain.GRAVE };
         randomTerrainFilter = new List<Terrain> { Terrain.DESERT, Terrain.GRASS, Terrain.FOREST, Terrain.SWAMP, Terrain.GRAVE, Terrain.MOUNTAIN };
-        if (props.HideLessImportantLocations)
+        if (props.LessImportantLocationsOption != LessImportantLocationsOption.ISOLATE)
         {
             unimportantLocs.Add(GetLocationByMem(RomMap.WEST_MINOR_FOREST_TILE_AT_START_LOCATION));
             unimportantLocs.Add(GetLocationByMem(RomMap.WEST_MINOR_FOREST_TILE_BY_SARIA_LOCATION));
@@ -711,8 +711,7 @@ public sealed class WestHyrule : World
 
                 BlockCaves(props.BoulderBlockConnections);
                 //Debug.WriteLine(GetMapDebug());
-                PlaceHiddenLocations();
-
+                PlaceHiddenLocations(props.LessImportantLocationsOption);
 
                 if (biome == Biome.CANYON || biome == Biome.DRY_CANYON)
                 {

--- a/RandomizerCore/Overworld/World.cs
+++ b/RandomizerCore/Overworld/World.cs
@@ -576,33 +576,52 @@ public abstract class World
         return true;
     }
 
-    public void PlaceHiddenLocations()
+    public void PlaceHiddenLocations(LessImportantLocationsOption lessImportantLocationsOption)
     {
-        foreach (Location location in unimportantLocs)
+        switch (lessImportantLocationsOption)
         {
-            if (location.CanShuffle)
-            {
-                int tries = 0;
-                int x, y;
-                do
+            case LessImportantLocationsOption.REMOVE:
+                foreach (Location location in unimportantLocs)
                 {
-                    x = RNG.Next(MAP_COLS);
-                    y = RNG.Next(MAP_ROWS);
-                    tries++;
-                } while ((map[y, x] != location.TerrainType || GetLocationByCoords((y + 30, x)) != null) && tries < 2000);
+                    if (location.CanShuffle)
+                    {
+                        location.ExternalWorld = 0;
+                        location.Ypos = 0;
+                        location.appear2loweruponexit = 0;
+                        location.Secondpartofcave = 0;
+                        location.Xpos = 0;
+                        location.CanShuffle = false;
+                    }
+                }
+                break;
+            case LessImportantLocationsOption.HIDE:
+                foreach (Location location in unimportantLocs)
+                {
+                    if (location.CanShuffle)
+                    {
+                        int tries = 0;
+                        int x, y;
+                        do
+                        {
+                            x = RNG.Next(MAP_COLS);
+                            y = RNG.Next(MAP_ROWS);
+                            tries++;
+                        } while ((map[y, x] != location.TerrainType || GetLocationByCoords((y + 30, x)) != null) && tries < 2000);
 
-                if (tries < 2000)
-                {
-                    location.Xpos = x;
-                    location.Ypos = y + 30;
+                        if (tries < 2000)
+                        {
+                            location.Xpos = x;
+                            location.Ypos = y + 30;
+                        }
+                        else
+                        {
+                            location.Xpos = 0;
+                            location.Ypos = 0;
+                        }
+                        location.CanShuffle = false;
+                    }
                 }
-                else
-                {
-                    location.Xpos = 0;
-                    location.Ypos = 0;
-                }
-                location.CanShuffle = false;
-            }
+                break;
         }
     }
 

--- a/RandomizerCore/RandomizerConfiguration.cs
+++ b/RandomizerCore/RandomizerConfiguration.cs
@@ -186,7 +186,7 @@ public sealed partial class RandomizerConfiguration : INotifyPropertyChanged
     private bool? shuffleWhichLocationIsHidden;
 
     [Reactive]
-    private bool? hideLessImportantLocations;
+    private LessImportantLocationsOption lessImportantLocationsOption;
 
     [Reactive]
     private bool? restrictConnectionCaveShuffle;
@@ -1103,6 +1103,20 @@ public sealed partial class RandomizerConfiguration : INotifyPropertyChanged
         properties.ShuffleHidden = shuffleWhichLocationIsHidden ?? GetIndeterminateFlagValue(r);
         properties.CanWalkOnWaterWithBoots = goodBoots ?? GetIndeterminateFlagValue(r);
         properties.BagusWoods = generateBaguWoods ?? GetIndeterminateFlagValue(r);
+        if (lessImportantLocationsOption == LessImportantLocationsOption.RANDOM)
+        {
+            properties.LessImportantLocationsOption = r.Next(3) switch
+            {
+                0 => LessImportantLocationsOption.HIDE,
+                1 => LessImportantLocationsOption.ISOLATE,
+                2 => LessImportantLocationsOption.REMOVE,
+                _ => throw new ImpossibleException("Invalid LessImportantLocationsOption random option in Export")
+            };
+        }
+        else
+        {
+            properties.LessImportantLocationsOption = LessImportantLocationsOption;
+        }
         if(riverDevilBlockerOption == RiverDevilBlockerOption.RANDOM)
         {
             properties.RiverDevilBlockerOption = r.Next(3) switch
@@ -1118,6 +1132,7 @@ public sealed partial class RandomizerConfiguration : INotifyPropertyChanged
             properties.RiverDevilBlockerOption = riverDevilBlockerOption;
         }
         properties.EastRocks = eastRocks ?? GetIndeterminateFlagValue(r);
+        properties.SaneCaves = RestrictConnectionCaveShuffle ?? GetIndeterminateFlagValue(r);
 
         properties.StartGems = r.Next(palacesToCompleteMin, palacesToCompleteMax + 1);
         properties.RequireTbird = tBirdRequired ?? GetIndeterminateFlagValue(r);
@@ -1192,6 +1207,7 @@ public sealed partial class RandomizerConfiguration : INotifyPropertyChanged
         properties.ShufflePalaceEnemies = shufflePalaceEnemies ?? GetIndeterminateFlagValue(r);
         properties.MixLargeAndSmallEnemies = mixLargeAndSmallEnemies ?? GetIndeterminateFlagValue(r);
         properties.ShuffleDripper = shuffleDripperEnemy;
+        properties.SpellEnemy = randomizeSpellSpellEnemy ?? GetIndeterminateFlagValue(r);
         properties.ShuffleEnemyPalettes = shuffleSpritePalettes;
         properties.EnemyXPDrops = enemyXPDrops;
 
@@ -1209,9 +1225,6 @@ public sealed partial class RandomizerConfiguration : INotifyPropertyChanged
         properties.MagicCap = magicLevelCap;
         properties.LifeCap = lifeLevelCap;
         properties.ScaleLevels = scaleLevelRequirementsToCap;
-        properties.HideLessImportantLocations = hideLessImportantLocations ?? GetIndeterminateFlagValue(r);
-        properties.SaneCaves = restrictConnectionCaveShuffle ?? GetIndeterminateFlagValue(r);
-        properties.SpellEnemy = randomizeSpellSpellEnemy ?? GetIndeterminateFlagValue(r);
 
         //Items
         properties.ShuffleOverworldItems = shuffleOverworldItems ?? GetIndeterminateFlagValue(r);

--- a/RandomizerCore/RandomizerProperties.cs
+++ b/RandomizerCore/RandomizerProperties.cs
@@ -92,6 +92,8 @@ public class RandomizerProperties
     public bool ShuffleHidden { get; set; }
     public bool CanWalkOnWaterWithBoots { get; set; }
     public bool BagusWoods { get; set; }
+    public LessImportantLocationsOption LessImportantLocationsOption { get; set; }
+    public bool SaneCaves { get; set; }
     public RiverDevilBlockerOption RiverDevilBlockerOption { get; set; }
     public bool EastRocks { get; set; }
 
@@ -150,8 +152,6 @@ public class RandomizerProperties
     public int MagicCap { get; set; }
     public int LifeCap { get; set; }
     public bool ScaleLevels { get; set; }
-    public bool HideLessImportantLocations { get; set; }
-    public bool SaneCaves { get; set; }
     public bool SpellEnemy { get; set; }
 
     //Items


### PR DESCRIPTION
Actually change the tri-state option into a 4 enum option.
<img width="754" height="318" alt="image" src="https://github.com/user-attachments/assets/98d27380-f5dd-4ba6-bcb9-a01bf2caa3cd" />
