### PR TITLE
Make the text boxes dynamically resize to up to 6 lines long

### DIFF
--- a/RandomizerCore/Asm/z2r.inc
+++ b/RandomizerCore/Asm/z2r.inc
@@ -195,6 +195,9 @@ NmiBankShadow8 = $6380
 NmiBankShadowA = $6381
 SoftDisableNmi = $6382
 
+; Flag to store if the dialog has ended
+DialogCompleteTmp = $0523
+
 StatTrackingBase = $6383
 SET_RES_BASE StatTrackingBase
 


### PR DESCRIPTION
Also fixes a really dumb workaround i put into the original instant text patch.

This change makes it so that text boxes rescale from 4 minimum to 6 maximum in length.