### PR TITLE
Add Git branch & hash to displayed version (if not on main)

### DIFF
--- a/CrossPlatformUI/App.axaml.cs
+++ b/CrossPlatformUI/App.axaml.cs
@@ -24,12 +24,19 @@ public sealed partial class App : Application // , IDisposable
         AvaloniaXamlLoader.Load(this);
 
         var version = Assembly.GetExecutingAssembly().GetName().Version;
-        Version = $"{version?.ToString(version.Revision > 0 ? 4 : 3)}";
+        if (Z2Randomizer.GitInfo.Branch == "main")
+        {
+            Version = $"v{version?.ToString(version.Revision > 0 ? 4 : 3)}";
+        }
+        else
+        {
+            Version = $"[{Z2Randomizer.GitInfo.Branch}:{Z2Randomizer.GitInfo.Commit}]";
+        }
 #if DEBUG
         Version += " (Debug)";
 #endif
 
-        Title = $"Zelda II Randomizer v{Version}";
+        Title = $"Zelda II Randomizer {Version}";
     }
 
     public static ServiceCollection? ServiceContainer;

--- a/CrossPlatformUI/CrossPlatformUI.csproj
+++ b/CrossPlatformUI/CrossPlatformUI.csproj
@@ -41,6 +41,42 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\RandomizerCore\RandomizerCore.csproj" />
+        <ProjectReference Include="..\RandomizerCore\RandomizerCore.csproj" />
     </ItemGroup>
+
+    <Target Name="GenerateGitInfo" BeforeTargets="BeforeBuild">
+        <MakeDir Directories="$(IntermediateOutputPath)" />
+        <Exec Command="git rev-parse --short HEAD > $(IntermediateOutputPath)git-hash.txt" />
+        <Exec Command="git rev-parse --abbrev-ref HEAD > $(IntermediateOutputPath)git-branch.txt" />
+        <Exec Command="git diff --quiet || echo dirty > $(IntermediateOutputPath)git-dirty.txt" IgnoreExitCode="true" />
+
+        <ReadLinesFromFile File="$(IntermediateOutputPath)git-hash.txt"><Output TaskParameter="Lines" PropertyName="GitHash" /></ReadLinesFromFile>
+        <ReadLinesFromFile File="$(IntermediateOutputPath)git-branch.txt"><Output TaskParameter="Lines" PropertyName="GitBranch" /></ReadLinesFromFile>
+        <ReadLinesFromFile File="$(IntermediateOutputPath)git-dirty.txt" Condition="Exists('$(IntermediateOutputPath)gitdirty.txt')"><Output TaskParameter="Lines" PropertyName="GitDirty" /></ReadLinesFromFile>
+        <PropertyGroup><IsDirtyValue>false</IsDirtyValue></PropertyGroup>
+        <PropertyGroup Condition="'$(GitDirty)' != ''"><IsDirtyValue>true</IsDirtyValue></PropertyGroup>
+    </Target>
+
+    <Target Name="WriteGitInfoFile" DependsOnTargets="GenerateGitInfo" BeforeTargets="BeforeBuild">
+
+      <PropertyGroup>
+        <GitInfoText>// (auto-generated from .csproj)
+    namespace Z2Randomizer;
+    public static class GitInfo {
+        public const string Commit = &quot;$(GitHash)&quot;;
+        public const string Branch = &quot;$(GitBranch)&quot;;
+        public const bool IsDirty = $(IsDirtyValue);
+    }
+    </GitInfoText>
+      </PropertyGroup>
+
+      <WriteLinesToFile
+          File="$(IntermediateOutputPath)GitInfo.cs"
+          Overwrite="true"
+          Lines="$([System.Text.RegularExpressions.Regex]::Split('$(GitInfoText)', '\n'))" />
+
+      <ItemGroup>
+          <Compile Include="$(IntermediateOutputPath)GitInfo.cs" />
+      </ItemGroup>
+    </Target>
 </Project>

--- a/CrossPlatformUI/ViewModels/RandomizerViewModel.cs
+++ b/CrossPlatformUI/ViewModels/RandomizerViewModel.cs
@@ -66,7 +66,7 @@ public class RandomizerViewModel : ReactiveValidationObject, IRoutableViewModel,
     [JsonIgnore]
     public string AppVersion
     {
-        get => $"Z2R v{App.Version}";
+        get => $"Z2R {App.Version}";
     }
 
     [JsonConstructor]


### PR DESCRIPTION
There were NuGet packages for this but they seemed annoying to work with.

Also I'm not sure $(IntermediateOutputPath)GitInfo.cs is the optimal file path for this.

Also hopefully this runs properly from the GitHub workloads.