### PR TITLE
Work on palaces for new palace styles

### DIFF
--- a/RandomizerCore/Sidescroll/ChaosPalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/ChaosPalaceGenerator.cs
@@ -18,6 +18,8 @@ internal class ChaosPalaceGenerator : PalaceGenerator
         debug++;
         bool duplicateProtection = (props.NoDuplicateRooms || props.NoDuplicateRoomsBySideview) && AllowDuplicatePrevention(props, palaceNumber);
         RoomPool roomPool = new(rooms);
+        ILookup<string, Room>? duplicateRoomLookup = CreateRoomVariantsLookupOrNull(props, palaceNumber, roomPool);
+        DetermineRoomVariants(r, duplicateRoomLookup, roomPool.NormalRooms);
         Palace palace = new(palaceNumber);
         var palaceGroup = Util.AsPalaceGrouping(palaceNumber);
 
@@ -90,7 +92,7 @@ internal class ChaosPalaceGenerator : PalaceGenerator
             int roomIndex = r.Next(roomPool.NormalRooms.Count);
             Room newRoom = new(roomPool.NormalRooms[roomIndex]);
             palace.AllRooms.Add(newRoom);
-            if (duplicateProtection) { RemoveDuplicatesFromPool(props, roomPool.NormalRooms, newRoom); }
+            if (duplicateProtection) { RemoveDuplicatesFromPool(roomPool.NormalRooms, newRoom); }
         }
 
         Dictionary<Room, RoomExitType> roomExits = [];

--- a/RandomizerCore/Sidescroll/Palace.cs
+++ b/RandomizerCore/Sidescroll/Palace.cs
@@ -1045,7 +1045,7 @@ public partial class Palace
         return unclearableRooms.Count == 0;
     }
 
-    public bool HasInescapableDrop(bool palacesContinueAfterBoss)
+    public bool HasInescapableDrop(bool exitViaBossRoomAllowed)
     {
         //get a list of effective drop zones in the palace
         List<Room> dropZonesToCheck = [];
@@ -1069,7 +1069,7 @@ public partial class Palace
             {
                 Room room = pendingRooms.Pop();
                 //if you find the entrance, remove and continue
-                if (room == Entrance || (room.IsBossRoom && !palacesContinueAfterBoss))
+                if (room == Entrance || (room.IsBossRoom && exitViaBossRoomAllowed))
                 {
                     found = true;
                     break;

--- a/RandomizerCore/Sidescroll/RandomWalkCoordinatePalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/RandomWalkCoordinatePalaceGenerator.cs
@@ -28,11 +28,11 @@ public class RandomWalkCoordinatePalaceGenerator : ShapeFirstCoordinatePalaceGen
         var currentCoord = Coord.Origin;
 
         //Back to even weight for now.
-        WeightedRandom<int> weightedRandomDirection = new([
-            (0, 35),  // left
-            (1, 35),  // down
-            (2, 35),  // up
-            (3, 35),  // right
+        TableWeightedRandom<int> weightedRandomDirection = new([
+            (0, 1),  // left
+            (1, 1),  // down
+            (2, 1),  // up
+            (3, 1),  // right
         ]);
 
         //Create graph

--- a/RandomizerCore/Sidescroll/ReconstructedPalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/ReconstructedPalaceGenerator.cs
@@ -237,7 +237,7 @@ public class ReconstructedPalaceGenerator(CancellationToken ct) : PalaceGenerato
                 (!reachable
                  || (palaceNumber == 7 && props.RequireTbird && !palace.RequiresThunderbird())
                  || (palaceNumber == 7 && !palace.BossRoomMinDistance(props.DarkLinkMinDistance))
-                 || palace.HasInescapableDrop(props.BossRoomsExitToPalace[palace.Number - 1])
+                 || palace.HasInescapableDrop(!props.BossRoomsExitToPalace[palace.Number - 1])
                 ) && (tries < ROOM_SHUFFLE_ATTEMPT_LIMIT)
             );
         } while (tries >= ROOM_SHUFFLE_ATTEMPT_LIMIT);

--- a/RandomizerCore/Sidescroll/ReconstructedPalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/ReconstructedPalaceGenerator.cs
@@ -23,10 +23,12 @@ public class ReconstructedPalaceGenerator(CancellationToken ct) : PalaceGenerato
         bool duplicateProtection = (props.NoDuplicateRooms || props.NoDuplicateRoomsBySideview) && AllowDuplicatePrevention(props, palaceNumber);
         // var palaceGroup = Util.AsPalaceGrouping(palaceNumber);
         Palace palace = new(palaceNumber);
+        ILookup<string, Room>? duplicateRoomLookup = CreateRoomVariantsLookupOrNull(props, palaceNumber, rooms);
         do // while (tries >= PALACE_SHUFFLE_ATTEMPT_LIMIT);
         {
             await Task.Yield();
             RoomPool roomPool = new(rooms);
+            DetermineRoomVariants(r, duplicateRoomLookup, roomPool.NormalRooms);
             if (ct.IsCancellationRequested)
             {
                 palace.IsValid = false;
@@ -83,7 +85,7 @@ public class ReconstructedPalaceGenerator(CancellationToken ct) : PalaceGenerato
                         palace.ItemRooms.Add(itemRoom);
                         palace.AllRooms.Add(itemRoom);
 
-                        if (duplicateProtection) { RemoveDuplicatesFromPool(props, roomPool.ItemRoomsByDirection[itemRoomDirection], itemRoom); }
+                        if (duplicateProtection) { RemoveDuplicatesFromPool(roomPool.ItemRoomsByDirection[itemRoomDirection], itemRoom); }
 
                         if (itemRoom.LinkedRoomName != null)
                         {
@@ -147,7 +149,7 @@ public class ReconstructedPalaceGenerator(CancellationToken ct) : PalaceGenerato
                     }
                     if (added)
                     {
-                        if (duplicateProtection) { RemoveDuplicatesFromPool(props, roomPool.NormalRooms, roomToAdd); }
+                        if (duplicateProtection) { RemoveDuplicatesFromPool(roomPool.NormalRooms, roomToAdd); }
                         if (roomToAdd.LinkedRoom?.HasDrop ?? false)
                         {
                             roomToAdd = roomToAdd.LinkedRoom;
@@ -172,7 +174,7 @@ public class ReconstructedPalaceGenerator(CancellationToken ct) : PalaceGenerato
                                 bool added2 = AddRoom(palace, dropZoneRoom, props.BlockersAnywhere);
                                 if (added2)
                                 {
-                                    if (duplicateProtection) { RemoveDuplicatesFromPool(props, roomPool.NormalRooms, dropZoneRoom); }
+                                    if (duplicateProtection) { RemoveDuplicatesFromPool(roomPool.NormalRooms, dropZoneRoom); }
                                     continueDropping = dropZoneRoom.HasDrop;
                                     if (dropZoneRoom.LinkedRoomName != null)
                                     {

--- a/RandomizerCore/Sidescroll/SequentialPlacementCoordinatePalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/SequentialPlacementCoordinatePalaceGenerator.cs
@@ -235,7 +235,7 @@ public class SequentialPlacementCoordinatePalaceGenerator : CoordinatePalaceGene
         //Recategorize the remaining rooms after stubbing out.
         roomsByExitType = roomPool.CategorizeNormalRoomExits();
 
-        if (palace.HasInescapableDrop(props.BossRoomsExitToPalace[palace.Number - 1]))
+        if (palace.HasInescapableDrop(!props.BossRoomsExitToPalace[palace.Number - 1]))
         {
             palace.IsValid = false;
             return palace;

--- a/RandomizerCore/Sidescroll/ShapeFirstCoordinatePalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/ShapeFirstCoordinatePalaceGenerator.cs
@@ -18,6 +18,7 @@ public abstract class ShapeFirstCoordinatePalaceGenerator() : CoordinatePalaceGe
         Palace palace = new(palaceNumber);
         Dictionary<RoomExitType, List<Room>> roomsByExitType;
         RoomPool roomPool = new(rooms);
+        ILookup<string, Room>? duplicateRoomLookup = CreateRoomVariantsLookupOrNull(props, palaceNumber, roomPool);
         // var palaceGroup = Util.AsPalaceGrouping(palaceNumber);
 
         Dictionary<Coord, RoomExitType> shape = GetPalaceShape(props, palace, roomPool, r, roomCount).Result;
@@ -29,6 +30,10 @@ public abstract class ShapeFirstCoordinatePalaceGenerator() : CoordinatePalaceGe
 
         //Add rooms
         roomsByExitType = roomPool.CategorizeNormalRoomExits(true);
+        foreach (var roomsForExitType in roomsByExitType.Values)
+        {
+            DetermineRoomVariants(r, duplicateRoomLookup, roomsForExitType);
+        }
         Dictionary<RoomExitType, bool> stubOnlyExitTypes = new();
         foreach (KeyValuePair<Coord, RoomExitType> item in shape.OrderBy(i => i.Key.X).ThenByDescending(i => i.Key.Y))
         {
@@ -58,6 +63,8 @@ public abstract class ShapeFirstCoordinatePalaceGenerator() : CoordinatePalaceGe
                 if (duplicateProtection && roomCandidates!.Count == 0)
                 {
                     roomCandidates = roomPool.GetNormalRoomsForExitType(roomExitType, true);
+                    // as the pool is re-used for this shape, determine variants to include again
+                    DetermineRoomVariants(r, duplicateRoomLookup, roomCandidates);
                     Debug.Assert(roomCandidates.Count() > 0);
                     roomsByExitType[roomExitType] = roomCandidates;
                     logger.Debug($"RandomWalk ran out of rooms of exit type: {roomExitType} in palace {palaceNumber}. Starting to use duplicate rooms.");
@@ -73,7 +80,7 @@ public abstract class ShapeFirstCoordinatePalaceGenerator() : CoordinatePalaceGe
                         break;
                     }
                 }
-                if (newRoom != null && duplicateProtection) { RemoveDuplicatesFromPool(props, roomCandidates!, newRoom); }
+                if (newRoom != null && duplicateProtection) { RemoveDuplicatesFromPool(roomCandidates!, newRoom); }
             }
 
             if (newRoom == null)

--- a/RandomizerCore/Sidescroll/VanillaPalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/VanillaPalaceGenerator.cs
@@ -98,7 +98,7 @@ public class VanillaPalaceGenerator() : PalaceGenerator
 
         if(!palace.AllReachable() 
             || (palaceNumber == 7 && props.RequireTbird && !palace.RequiresThunderbird()) 
-            || palace.HasInescapableDrop(props.BossRoomsExitToPalace[palace.Number - 1]))
+            || palace.HasInescapableDrop(!props.BossRoomsExitToPalace[palace.Number - 1]))
         {
             throw new Exception("Vanilla palace (" + palaceNumber + ") was not all reachable. This should be impossible.");
         }

--- a/RandomizerCore/Sidescroll/VanillaShufflePalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/VanillaShufflePalaceGenerator.cs
@@ -17,7 +17,7 @@ public class VanillaShufflePalaceGenerator() : VanillaPalaceGenerator()
             !palace.AllReachable() 
             || (palaceNumber == 7 && props.RequireTbird && !palace.RequiresThunderbird())
             || (palaceNumber == 7 && !palace.BossRoomMinDistance(props.DarkLinkMinDistance))
-            || palace.HasInescapableDrop(props.BossRoomsExitToPalace[palace.Number - 1])
+            || palace.HasInescapableDrop(!props.BossRoomsExitToPalace[palace.Number - 1])
         )
         {
             palace.ResetRooms();

--- a/RandomizerCore/WeightedRandom.cs
+++ b/RandomizerCore/WeightedRandom.cs
@@ -1,42 +1,156 @@
 ﻿using System;
-using System.Diagnostics;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace Z2Randomizer.RandomizerCore;
 
-public class WeightedRandom<T>
+public interface IWeightedSampler<T>
+{
+    T Next(Random r);
+    IEnumerable<T> Keys();
+    IWeightedSampler<T> Remove(T t);
+    int Weight(T t);
+    IWeightedSampler<T> Clone();
+}
+
+
+/// Best option for small weight sums
+/// Construction time proportional to total weight sum.
+/// Memory usage proportional to total weight sum (bad if weights are large).
+/// Sampling is O(1).
+public class TableWeightedRandom<T> : IWeightedSampler<T>
+    where T : notnull
+{
+    private readonly T[] _table;
+    private readonly int _totalWeight;
+    private readonly FrozenDictionary<T, int> _weights;
+
+    public TableWeightedRandom(IEnumerable<(T value, int weight)> entries)
+    {
+        int size;
+        if (entries == null || (size = entries.Count()) == 0) { throw new ArgumentException("Entries cannot be null or empty.", nameof(entries)); }
+
+        _weights = entries.ToFrozenDictionary(e => e.value, e => e.weight);
+        _totalWeight = _weights.Values.Sum();
+        _table = new T[_totalWeight];
+        int index = 0;
+
+        foreach (var (value, weight) in _weights)
+        {
+            for (int i = 0; i < weight; i++)
+            {
+                _table[index] = value;
+                index++;
+            }
+        }
+    }
+
+    public TableWeightedRandom(IEnumerable<KeyValuePair<T, int>> dict)
+    : this(dict.Select(kvp => (kvp.Key, kvp.Value)))
+    {
+    }
+
+    private TableWeightedRandom(T[] table, int totalWeight, FrozenDictionary<T, int> weights)
+    {
+        _table = table;
+        _totalWeight = totalWeight;
+        _weights = weights;
+    }
+
+    public IWeightedSampler<T> Clone()
+    {
+        return new TableWeightedRandom<T>(_table, _totalWeight, _weights);
+    }
+
+    public T Next([NotNull] Random r)
+    {
+        int roll = r.Next(0, _totalWeight);
+        return _table[roll];
+    }
+
+    public IEnumerable<T> Keys()
+    {
+        return _weights.Keys;
+    }
+
+    /// Note: This returns a new copy of the class. This is pretty slow,
+    /// but also needing this should be avoided in the first place.
+    public IWeightedSampler<T> Remove(T t)
+    {
+        if (!_weights.ContainsKey(t))
+        {
+            return this;
+        }
+
+        var newWeights = new Dictionary<T, int>(_weights);
+        newWeights.Remove(t);
+
+        return new TableWeightedRandom<T>(
+            newWeights.Select(kvp => (kvp.Key, kvp.Value))
+        );
+    }
+
+    public int Weight(T t)
+    {
+        return _weights[t];
+    }
+}
+
+/// Good for modest n (hundreds or less) where total weight is too big for TableWeightedRandom
+/// Construction time O(n).
+/// Memory usage O(n), independent of weight magnitudes.
+/// Sampling is O(n) (linear scan).
+public class LinearWeightedRandom<T> : IWeightedSampler<T>
 {
     private readonly T[] _values;
     private readonly int[] _cumulativeWeights;
     private readonly int _totalWeight;
 
-    public WeightedRandom((T value, int weight)[] entries)
+    public LinearWeightedRandom(IEnumerable<(T, int)> entries)
     {
-        if (entries == null || entries.Length == 0) { throw new ArgumentException("Entries cannot be null or empty.", nameof(entries)); }
+        int size;
+        if (entries == null || (size = entries.Count()) == 0) { throw new ArgumentException("Entries cannot be null or empty.", nameof(entries)); }
 
-        _values = new T[entries.Length];
-        _cumulativeWeights = new int[entries.Length];
+        _values = new T[size];
+        _cumulativeWeights = new int[size];
 
+        int i = 0;
         int total = 0;
-        for (int i = 0; i < entries.Length; i++)
+        foreach (var (value, weight) in entries)
         {
-            T value = entries[i].value;
-            int weight = entries[i].weight;
-
-            if (weight <= 0) { throw new ArgumentException($"Weight must be positive (entry {i})."); }
+            if (weight < 0) { throw new ArgumentException($"Weight must be positive (entry {i})."); }
 
             total += weight;
             _values[i] = value;
             _cumulativeWeights[i] = total;
+            i++;
         }
 
         _totalWeight = total;
     }
 
-    public T Next(Random rng)
+    public LinearWeightedRandom(IEnumerable<KeyValuePair<T, int>> dict)
+    : this(dict.Select(kvp => (kvp.Key, kvp.Value)))
     {
-        Debug.Assert(rng != null);
+    }
 
-        int roll = rng.Next(0, _totalWeight);
+    private LinearWeightedRandom(T[] values, int[] cumulativeWeights, int totalWeight)
+    {
+        _values = values;
+        _cumulativeWeights = cumulativeWeights;
+        _totalWeight = totalWeight;
+    }
+
+    public IWeightedSampler<T> Clone()
+    {
+        return new LinearWeightedRandom<T>(_values, _cumulativeWeights, _totalWeight);
+    }
+
+    public T Next([NotNull] Random r)
+    {
+        int roll = r.Next(0, _totalWeight);
 
         for (int i = 0; i < _cumulativeWeights.Length; ++i)
         {
@@ -47,5 +161,100 @@ public class WeightedRandom<T>
         }
 
         throw new ImpossibleException("Failed to select a value.");
+    }
+
+    public IEnumerable<T> Keys()
+    {
+        return _values;
+    }
+
+    public IWeightedSampler<T> Remove(T t)
+    {
+        int i = 0;
+        int length = _values.Length;
+        List<T> values = new(length);
+        List<int> cumulativeWeights = new(length);
+        int lastTotal = 0;
+        int removedWeight = 0;
+
+        for (; i < length; i++)
+        {
+            T v = _values[i]!;
+            if (t!.Equals(v))
+            {
+                removedWeight = _cumulativeWeights[i] - lastTotal;
+                break;
+            }
+            lastTotal = _cumulativeWeights[i];
+            values.Add(v);
+            cumulativeWeights.Add(lastTotal);
+        }
+        for (i++; i < length; i++) // append subtracted cumulatives for values that followed the removed value
+        {
+            values.Add(_values[i]);
+            cumulativeWeights.Add(_cumulativeWeights[i] - removedWeight);
+        }
+
+        return new LinearWeightedRandom<T>(values.ToArray(), cumulativeWeights.ToArray(), _totalWeight - removedWeight); ;
+    }
+
+    public int Weight(T t)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+public class WeightedShuffler<T>
+    where T : notnull
+{
+    private readonly FrozenDictionary<T, int> _weights;
+
+    public WeightedShuffler(FrozenDictionary<T, int> weights)
+    {
+        _weights = weights;
+    }
+
+    public WeightedShuffler(IEnumerable<(T value, int weight)> entries)
+    {
+        int size;
+        if (entries == null || (size = entries.Count()) == 0) { throw new ArgumentException("Entries cannot be null or empty.", nameof(entries)); }
+
+        _weights = entries.ToFrozenDictionary(e => e.value, e => e.weight);
+    }
+
+    public WeightedShuffler(IEnumerable<KeyValuePair<T, int>> dict)
+    : this(dict.Select(kvp => (kvp.Key, kvp.Value)))
+    {
+    }
+
+    /// <summary>
+    /// Returns all values shuffled using weights to prioritize sorting
+    /// values earlier in the list.
+    /// </summary>
+    public T[] Shuffle([NotNull] Random r)
+    {
+        int length = _weights.Count;
+        if (length == 0) { return Array.Empty<T>(); }
+
+        // will contain random rolls 0..1 to the exponent 1/weight
+        var tuple = new (double key, T value)[length];
+        int i = 0;
+        foreach (var (value, weight) in _weights)
+        {
+            double d = r.NextDouble();
+            double exp = Math.Pow(d, 1.0 / weight);
+            tuple[i] = (exp, value);
+            i++;
+        }
+
+        // higher keys first
+        Array.Sort(tuple, (a, b) => b.key.CompareTo(a.key));
+
+        var result = new T[length];
+        for (i = 0; i < length; i++)
+        {
+            result[i] = tuple[i].value;
+        }
+        return result;
     }
 }


### PR DESCRIPTION
(This builds on the weights PR)

[Remove room selection bias for rooms with multiple variants](https://github.com/Ellendar/Z2Randomizer/commit/08523e1b32d7237ea87b5ce65f906c3f3a0cb047)

[Extract abstract ShapeCoordinatePalaceGenerator from RandomWalk](https://github.com/Ellendar/Z2Randomizer/commit/f146611742db754563a16feb138004e8b297a9e6)
Only minor thing here is there is one less check that the room pool contains a drop stub since the room pool is not known in that logic.

[Try running FillShapeWithRooms a few times before giving up](https://github.com/Ellendar/Z2Randomizer/commit/df894fb2cf12f67500cacf75c68cffccf2fc6479)

Update: added
[Add a roll for whether palaces may have one-way drops to bosses](https://github.com/Ellendar/Z2Randomizer/pull/375/commits/d764d3583ec39cebc23ed819993488fad4d01235)