### PR TITLE
Add Vanilla-Weighted palace style

### DIFF
--- a/RandomizerCore/EnumTypes.cs
+++ b/RandomizerCore/EnumTypes.cs
@@ -207,6 +207,8 @@ public enum PalaceStyle
     SEQUENTIAL,
     [Description("Random Walk")]
     RANDOM_WALK,
+    [Description("Vanilla-Weighted")]
+    VANILLA_WEIGHTED,
     [Description("Tower")]
     TOWER,
     [Description("Chaos")]
@@ -246,6 +248,7 @@ public static class PalaceStyleExtensions
         {
             PalaceStyle.SEQUENTIAL => true,
             PalaceStyle.RANDOM_WALK => true,
+            PalaceStyle.VANILLA_WEIGHTED => true,
             PalaceStyle.TOWER => true,
             _ => false
         };

--- a/RandomizerCore/Sidescroll/Palace.cs
+++ b/RandomizerCore/Sidescroll/Palace.cs
@@ -185,6 +185,40 @@ public partial class Palace
         return false; // Boss room not found??
     }
 
+    /// same algorithm as BossRoomMinDistance except for shapes instead of rooms
+    public static bool BossRoomMinDistanceShape(Dictionary<Coord, RoomExitType> shape, Coord bossRoom, int minSteps)
+    {
+        // quick check on (non-diagonal) orthogonal distance alone
+        if (Math.Abs(bossRoom.X) + Math.Abs(bossRoom.Y) >= minSteps) {
+            return true;
+        }
+        HashSet<Coord> reachedRooms = [];
+        Queue<(Coord, int)> roomsToCheck = [];
+        roomsToCheck.Enqueue((new Coord(0, 0), 0));
+        while (roomsToCheck.Count > 0)
+        {
+            var (coord, stepsToRoom) = roomsToCheck.Dequeue();
+            if (stepsToRoom >= minSteps)
+            {
+                return true;
+            }
+            if (coord == bossRoom)
+            {
+                return false;
+            }
+            var exitType = shape[coord];
+
+            if (!reachedRooms.Add(coord)) { continue; }
+
+            int stepsToNextRoom = stepsToRoom + 1;
+            if (exitType.ContainsLeft()) { roomsToCheck.Enqueue((coord with { X = coord.X - 1}, stepsToNextRoom)); }
+            if (exitType.ContainsRight()) { roomsToCheck.Enqueue((coord with { X = coord.X + 1 }, stepsToNextRoom)); }
+            if (exitType.ContainsUp()) { roomsToCheck.Enqueue((coord with { Y = coord.Y + 1 }, stepsToNextRoom)); }
+            if (exitType.ContainsDown()) { roomsToCheck.Enqueue((coord with { Y = coord.Y - 1 }, stepsToNextRoom)); }
+        }
+        return false; // Boss room not found?
+    }
+
     public bool AllReachable(bool allowBacktracking = false)
     {
         var reachableRooms = GetReachableRooms(allowBacktracking);

--- a/RandomizerCore/Sidescroll/PalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/PalaceGenerator.cs
@@ -71,6 +71,7 @@ public abstract class PalaceGenerator
             case PalaceStyle.TOWER:
             case PalaceStyle.SEQUENTIAL:
             case PalaceStyle.RANDOM_WALK: // not implemented
+            case PalaceStyle.VANILLA_WEIGHTED: // based on Random Walk
                 return;
         }
         if (!AllowDuplicatePrevention(props, palace.Number)) { return; }

--- a/RandomizerCore/Sidescroll/Palaces.cs
+++ b/RandomizerCore/Sidescroll/Palaces.cs
@@ -72,6 +72,7 @@ public class Palaces
                 PalaceStyle.SHUFFLED => new VanillaShufflePalaceGenerator(),
                 PalaceStyle.SEQUENTIAL => new SequentialPlacementCoordinatePalaceGenerator(),
                 PalaceStyle.RANDOM_WALK => new RandomWalkCoordinatePalaceGenerator(),
+                PalaceStyle.VANILLA_WEIGHTED => new VanillaWeightedPalaceGenerator(),
                 PalaceStyle.TOWER => new TowerCoordinatePalaceGenerator(),
                 PalaceStyle.RECONSTRUCTED => new ReconstructedPalaceGenerator(ct),
                 PalaceStyle.CHAOS => new ChaosPalaceGenerator(),

--- a/RandomizerCore/Sidescroll/RandomWalkCoordinatePalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/RandomWalkCoordinatePalaceGenerator.cs
@@ -12,6 +12,19 @@ public class RandomWalkCoordinatePalaceGenerator : ShapeFirstCoordinatePalaceGen
     private const float DROP_CHANCE = .06f;
     private static readonly ItemRoomSelectionStrategy itemRoomSelectionStrategy = new ByShapeItemRoomSelectionStrategy();
 
+
+    private static readonly TableWeightedRandom<int> _weightedRandomDirection = new([
+        (0, 1),  // left
+        (1, 1),  // down
+        (2, 1),  // up
+        (3, 1),  // right
+    ]);
+
+    protected virtual IWeightedSampler<int> GetDirectionWeights(int palaceNumber)
+    {
+        return _weightedRandomDirection;
+    }
+
     protected override async Task<Dictionary<Coord, RoomExitType>> GetPalaceShape(RandomizerProperties props, Palace palace, RoomPool roomPool, Random r, int roomCount)
     {
         Dictionary<Coord, RoomExitType> walkGraph = [];
@@ -29,13 +42,7 @@ public class RandomWalkCoordinatePalaceGenerator : ShapeFirstCoordinatePalaceGen
 
         var currentCoord = Coord.Origin;
 
-        //Back to even weight for now.
-        TableWeightedRandom<int> weightedRandomDirection = new([
-            (0, 35),  // left
-            (1, 35),  // down
-            (2, 35),  // up
-            (3, 35),  // right
-        ]);
+        var weightedRandomDirection = GetDirectionWeights(palace.Number);
 
         //Create graph
         while (walkGraph.Count < roomCount)

--- a/RandomizerCore/Sidescroll/VanillaWeightedPalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/VanillaWeightedPalaceGenerator.cs
@@ -1,0 +1,94 @@
+﻿using System;
+
+namespace Z2Randomizer.RandomizerCore.Sidescroll;
+
+public class VanillaWeightedPalaceGenerator : RandomWalkCoordinatePalaceGenerator
+{
+    private static readonly TableWeightedRandom<int>[] WeightedRandomDirections = [
+        new([ // Palace 1  (7x3 in vanilla)
+            (0, 7),  // left
+            (1, 3),  // down
+            (2, 3),  // up
+            (3, 7),  // right
+        ]),
+        new([ // Palace 2  (8x4 in vanilla)
+            (0, 2),  // left
+            (1, 1),  // down
+            (2, 1),  // up
+            (3, 2),  // right
+        ]),
+        new([ // Palace 3  (7x3 in vanilla)
+            (0, 7),  // left
+            (1, 3),  // down
+            (2, 3),  // up
+            (3, 7),  // right
+        ]),
+        new([ // Palace 4  (6x4 in vanilla)
+            (0, 3),  // left
+            (1, 2),  // down
+            (2, 2),  // up
+            (3, 3),  // right
+        ]),
+        new([ // Palace 5  (7x5 in vanilla)
+            (0, 7),  // left
+            (1, 5),  // down
+            (2, 5),  // up
+            (3, 7),  // right
+        ]),
+        new([ // Palace 6  (10x6 in vanilla)
+            (0, 5),  // left
+            (1, 3),  // down
+            (2, 3),  // up
+            (3, 5),  // right
+        ]),
+        new([ // Great Palace  (10x13 in vanilla)
+            (0, 10),  // left
+            (1, 13),  // down
+            (2, 13),  // up
+            (3, 10),  // right
+        ]),
+    ];
+
+    // how many rooms you have to traverse to reach the boss in the vanilla palaces.
+    // does not include the entrance, but does include the boss room itself
+    private static readonly int[] VanillaDistanceToBosses = [
+        7,  // Palace 1
+        13, // Palace 2
+        10, // Palace 3
+        7,  // Palace 4
+        12, // Palace 5
+        13, // Palace 6
+        24, // GP
+    ];
+
+    protected override IWeightedSampler<int> GetDirectionWeights(int palaceNumber)
+    {
+        return WeightedRandomDirections[palaceNumber - 1];
+    }
+
+    protected override int GetBossMinDistance(RandomizerProperties props, int palaceNumber)
+    {
+        if (palaceNumber == 7)
+        {
+            // still just use the selected value for GP
+            return props.DarkLinkMinDistance;
+        }
+        // lets not alter the chance of items being behind the boss
+        bool continuesAfter = props.BossRoomsExitToPalace[palaceNumber - 1];
+        if (continuesAfter)
+        {
+            return 0;
+        }
+
+        double vanillaLength = Palaces.VANILLA_LENGTHS[palaceNumber - 1];
+        double length = props.PalaceLengths[palaceNumber - 1];
+        double lengthScale = length / vanillaLength;
+
+        // compress the min distance a bit for longer palaces
+        double a = 0.4; // compression aggressiveness
+        lengthScale = lengthScale / (1.0 + a * (lengthScale - 0.5));
+
+        double vanillaDistance = VanillaDistanceToBosses[palaceNumber - 1];
+        return (int)Math.Round((double)(vanillaDistance * lengthScale));
+    }
+}


### PR DESCRIPTION
- Subclass of RandomWalk
- ShapeFirst generator logic slightly changed to place the boss
  earlier - instead of replacing a room. This means we can check
  min. path to boss faster, and also retry with more boss room coord
  candidates.
- Vanilla-Weighted uses dimensions (width x height) of the vanilla
  palaces for weighting the random walk algorithm.
- Additionally min. path to boss is checked for all Vanilla-Weighted
  palaces (not just GP), with their vanilla distance to the boss being
  used. The value is also affected by the palace length percentage.
  However, this is ignored if the palace continues after the boss.