### PR TITLE
Vanilla Weighted Palace improvements

### DIFF
--- a/RandomizerCore/Sidescroll/ByShapeItemRoomSelectionStrategy.cs
+++ b/RandomizerCore/Sidescroll/ByShapeItemRoomSelectionStrategy.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Numerics;
-using System.Text;
 
 namespace Z2Randomizer.RandomizerCore.Sidescroll;
 
-internal class ByShapeItemRoomSelectionStrategy : ItemRoomSelectionStrategy
+internal class ByShapeItemRoomSelectionStrategy : ItemRoomSelectionStrategy, IItemRoomInShapeSelectionStrategy
 {
     private static readonly RoomExitType[] PRIORITY_ROOM_SHAPES = [];// [RoomExitType.DROP_STUB, RoomExitType.DROP_T];
     private const int MAX_ATTEMPTS = 200;
@@ -29,51 +27,40 @@ internal class ByShapeItemRoomSelectionStrategy : ItemRoomSelectionStrategy
 
             foreach (Room itemRoomCandidate in itemRoomCandidates)
             {
-                itemRoomPlaced = false;
-                if (itemRoomPlaced)
-                {
-                    break;
-                }
+                if (avoidDuplicates && originalItemRooms.Contains(itemRoomCandidate)) { continue; }
                 List<Room> itemRoomReplacementCandidates =
                     palace.AllRooms.Where(i => i.IsNormalRoom() && i.CategorizeExits() == itemRoomExitType && !replacedCoords.Contains(i.coords)).ToList();
 
                 itemRoomReplacementCandidates.FisherYatesShuffle(r);
                 foreach (Room itemRoomReplacementRoom in itemRoomReplacementCandidates)
                 {
-                    Room? upRoom = palace.AllRooms.FirstOrDefault(
-                        i => i.coords == itemRoomReplacementRoom.coords with { Y = itemRoomReplacementRoom.coords.Y + 1 });
-                    if (itemRoomReplacementRoom != null &&
-                        (upRoom == null || !upRoom.HasDownExit || upRoom.HasDrop == itemRoomCandidate.IsDropZone))
-                    {
-                        Room itemRoom = new(itemRoomCandidate);
-                        itemRoom.coords = itemRoomReplacementRoom.coords;
-                        if (itemRoomCandidate.LinkedRoomName != null)
-                        {
-                            Room linkedRoom = roomPool.LinkedRooms[itemRoomCandidate.LinkedRoomName];
-                            itemRoom = itemRoom.Merge(linkedRoom);
-                        }
-                        replacedCoords.Add(itemRoomReplacementRoom.coords);
-                        itemRoomNumber++;
-                        itemRoomPlaced = true;
+                    var coord = itemRoomReplacementRoom.coords;
+                    Room? upRoom = palace.AllRooms.FirstOrDefault(i => i.coords == coord with { Y = coord.Y + 1 });
+                    bool mustBeDropZone = upRoom != null && upRoom.HasDownExit && upRoom.HasDrop;
+                    if (mustBeDropZone && !itemRoomCandidate.IsDropZone) { continue; }
 
-                        if (!avoidDuplicates || !originalItemRooms.Contains(itemRoom))
-                        {
-                            originalItemRooms.Add(itemRoomCandidate);
-                            itemRooms.Add(itemRoom);
-                        }
-                        break;
-                    }
+                    Room itemRoom = CreateItemRoom(itemRoomCandidate, coord, roomPool);
+                    replacedCoords.Add(coord);
+                    itemRoomNumber++;
+                    itemRoomPlaced = true;
+                    originalItemRooms.Add(itemRoomCandidate);
+                    itemRooms.Add(itemRoom);
+                    break;
                 }
+                if (itemRoomPlaced) { break; }
             }
             if (!itemRoomPlaced)
             {
                 possibleItemRoomExitTypes.Remove(itemRoomExitType);
-                if(possibleItemRoomExitTypes.Count == 0)
+                if (possibleItemRoomExitTypes.Count == 0)
                 {
                     break;
                 }
             }
-
+            else
+            {
+                possibleItemRoomExitTypes.FisherYatesShuffle(r);
+            }
         }
         if (itemRoomCount == itemRooms.Count)
         {
@@ -81,6 +68,78 @@ internal class ByShapeItemRoomSelectionStrategy : ItemRoomSelectionStrategy
         }
         return [];
     }
+
+    public Room[] SelectItemRoomsInShape(RoomPool roomPool, int itemRoomCount, bool avoidDuplicates, Random r, Dictionary<Coord, RoomExitType> shape, IEnumerable<RoomExitType> itemRoomShapes, List<Coord> preplacedCoords)
+    {
+        List<RoomExitType> possibleItemRoomExitTypes = ShuffleItemRoomShapes(itemRoomShapes, r);
+        List<Room> itemRooms = [], originalItemRooms = [];
+        List<Coord> replacedCoords = [.. preplacedCoords];
+        int itemRoomNumber = 0, attemptNumber = 0;
+
+        while (itemRoomNumber < itemRoomCount && attemptNumber++ < MAX_ATTEMPTS)
+        {
+            RoomExitType itemRoomExitType = possibleItemRoomExitTypes[0];
+            List<Room> itemRoomCandidates = roomPool.GetItemRoomsForShape(itemRoomExitType).ToList();
+            itemRoomCandidates.FisherYatesShuffle(r);
+
+            bool itemRoomPlaced = false;
+
+            foreach (Room itemRoomCandidate in itemRoomCandidates)
+            {
+                if (avoidDuplicates && originalItemRooms.Contains(itemRoomCandidate)) { continue; }
+                var itemRoomCoordCandidates = shape.Where(pair => pair.Value == itemRoomExitType && !replacedCoords.Contains(pair.Key)).ToList();
+
+                itemRoomCoordCandidates.FisherYatesShuffle(r);
+                foreach (var pair in itemRoomCoordCandidates)
+                {
+                    var coord = pair.Key;
+                    var upCoord = coord with { Y = coord.Y + 1 };
+                    RoomExitType candidate = pair.Value;
+                    bool mustBeDropZone = shape.TryGetValue(upCoord, out var exit) && exit.ContainsDrop();
+                    if (mustBeDropZone && !itemRoomCandidate.IsDropZone) { continue; }
+
+                    Room itemRoom = CreateItemRoom(itemRoomCandidate, coord, roomPool);
+                    replacedCoords.Add(coord);
+                    itemRoomNumber++;
+                    itemRoomPlaced = true;
+                    originalItemRooms.Add(itemRoomCandidate);
+                    itemRooms.Add(itemRoom);
+                    break;
+                }
+                if (itemRoomPlaced) { break; }
+            }
+            if (!itemRoomPlaced)
+            {
+                possibleItemRoomExitTypes.Remove(itemRoomExitType);
+                if (possibleItemRoomExitTypes.Count == 0)
+                {
+                    break;
+                }
+            }
+            else
+            {
+                possibleItemRoomExitTypes.FisherYatesShuffle(r);
+            }
+        }
+        if (itemRoomCount == itemRooms.Count)
+        {
+            return itemRooms.ToArray();
+        }
+        return [];
+    }
+
+    private static Room CreateItemRoom(Room candidate, Coord coord, RoomPool pool)
+    {
+        Room itemRoom = new(candidate);
+        itemRoom.coords = coord;
+        if (candidate.LinkedRoomName != null)
+        {
+            Room linkedRoom = pool.LinkedRooms[candidate.LinkedRoomName];
+            itemRoom = itemRoom.Merge(new Room(linkedRoom));
+        }
+        return itemRoom;
+    }
+
     private static List<RoomExitType> ShuffleItemRoomShapes(IEnumerable<RoomExitType> possibleItemRoomExitTypes, Random r)
     {
         List<RoomExitType> priorityShapes = [.. possibleItemRoomExitTypes.Where(i => PRIORITY_ROOM_SHAPES.Contains(i))];

--- a/RandomizerCore/Sidescroll/CoordinatePalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/CoordinatePalaceGenerator.cs
@@ -23,22 +23,25 @@ public abstract class CoordinatePalaceGenerator : PalaceGenerator
         //ItemRoom
         if (palace.Number < 7)
         {
-            Room[] itemRooms = itemRoomSelector.SelectItemRooms(palace, roomPool, props.PalaceItemRoomCounts[palace.Number - 1], duplicateProtection, r);
-            if (itemRooms == null || itemRooms.Length != props.PalaceItemRoomCounts[palace.Number - 1])
+            if (palace.ItemRooms.Count != itemRoomTotal)
             {
-                return false;
-            }
-
-            foreach (Room itemRoom in itemRooms)
-            {
-                Room? itemRoomReplacementRoom = palace.AllRooms.FirstOrDefault(i => i.coords == itemRoom.coords);
-                if (itemRoomReplacementRoom == null)
+                Room[] itemRooms = itemRoomSelector.SelectItemRooms(palace, roomPool, itemRoomTotal, duplicateProtection, r);
+                if (itemRooms == null || itemRooms.Length != itemRoomTotal)
                 {
-                    throw new Exception("ItemRoomSelectionStrategy generated an item room replacement for a room that doesn't exist");
+                    return false;
                 }
-                palace.ReplaceRoom(itemRoomReplacementRoom, itemRoom);
-                palace.ItemRooms.Add(itemRoom);
-            } 
+
+                foreach (Room itemRoom in itemRooms)
+                {
+                    Room? itemRoomReplacementRoom = palace.AllRooms.FirstOrDefault(i => i.coords == itemRoom.coords);
+                    if (itemRoomReplacementRoom == null)
+                    {
+                        throw new Exception("ItemRoomSelectionStrategy generated an item room replacement for a room that doesn't exist");
+                    }
+                    palace.ReplaceRoom(itemRoomReplacementRoom, itemRoom);
+                    palace.ItemRooms.Add(itemRoom);
+                }
+            }
         }
         //Tbird Room
         else

--- a/RandomizerCore/Sidescroll/ItemRoomSelectionStrategy.cs
+++ b/RandomizerCore/Sidescroll/ItemRoomSelectionStrategy.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Z2Randomizer.RandomizerCore.Sidescroll;
 
 public abstract class ItemRoomSelectionStrategy
 {
     public abstract Room[] SelectItemRooms(Palace palace, RoomPool roomPool, int itemRoomCount, bool avoidDuplicates, Random r);
+}
+
+public interface IItemRoomInShapeSelectionStrategy
+{
+    Room[] SelectItemRoomsInShape(RoomPool roomPool, int itemRoomCount, bool duplicateProtection, Random r, Dictionary<Coord, RoomExitType> shape, IEnumerable<RoomExitType> itemRoomShapes, List<Coord> prepopulatedCoordinates);
 }

--- a/RandomizerCore/Sidescroll/Room.cs
+++ b/RandomizerCore/Sidescroll/Room.cs
@@ -10,12 +10,22 @@ using NLog;
 
 namespace Z2Randomizer.RandomizerCore.Sidescroll;
 
-public record struct Coord(int X, int Y)
+public record struct Coord(int X, int Y) : IComparable<Coord>
 {
     public Coord((int, int) coords) : this(coords.Item1, coords.Item2) {}
     public static Coord Uninitialized = new(0, 0);
     //I want a separate constant for this in case implementation changes the value of Unitialized, but origin should always be 0,0
     public static Coord Origin = new(0, 0);
+
+    public int CompareTo(Coord other)
+    {
+        int yComparison = Y.CompareTo(other.Y);
+        if (yComparison != 0)
+        {
+            return yComparison;
+        }
+        return X.CompareTo(other.X);
+    }
 }
 
 [JsonSourceGenerationOptions(

--- a/RandomizerCore/Sidescroll/ShapeFirstCoordinatePalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/ShapeFirstCoordinatePalaceGenerator.cs
@@ -19,6 +19,7 @@ public abstract class ShapeFirstCoordinatePalaceGenerator() : CoordinatePalaceGe
         Palace palace = new(palaceNumber);
         Dictionary<RoomExitType, List<Room>> roomsByExitType;
         RoomPool roomPool = new(rooms);
+        var itemRoomSelector = GetItemRoomSelectionStrategy();
         // var palaceGroup = Util.AsPalaceGrouping(palaceNumber);
 
         Dictionary<Coord, RoomExitType> shape;
@@ -38,13 +39,37 @@ public abstract class ShapeFirstCoordinatePalaceGenerator() : CoordinatePalaceGe
             }
         }
 
-        List < Coord > prepopulatedCoordinates = [];
+        List<Coord> prepopulatedCoordinates = [];
         prepopulatedCoordinates.Add(palace.AllRooms.FirstOrDefault(i => i.IsEntrance)?.coords ?? Coord.Uninitialized);
         prepopulatedCoordinates.Add(palace.AllRooms.FirstOrDefault(i => i.IsBossRoom)?.coords ?? Coord.Uninitialized);
+
+        int itemRoomCount = palace.Number < 7 ? props.PalaceItemRoomCounts[palace.Number - 1] : 0;
+        // place item rooms at the shape stage if strategy allows
+        if (palace.ItemRooms.Count < itemRoomCount && itemRoomSelector is IItemRoomInShapeSelectionStrategy shapeSelector)
+        {
+            var itemRoomShapes = GetItemRoomShapes(roomPool);
+            Room[] itemRooms = shapeSelector.SelectItemRoomsInShape(roomPool, itemRoomCount, duplicateProtection, r, shape, itemRoomShapes, prepopulatedCoordinates);
+            if (itemRooms.Length < itemRoomCount)
+            {
+                palace.IsValid = false;
+                return palace;
+            }
+            palace.ItemRooms = itemRooms.ToList();
+            palace.AllRooms.AddRange(palace.ItemRooms);
+
+            prepopulatedCoordinates.AddRange(palace.ItemRooms.Select(room => room.coords));
+        }
 
         //We aren't currently prepopulating thunderbird, but this should probably have some safety.
         //Too lazy for now
         //prepopulatedCoordinates.Add(palace.AllRooms.First(i => i.IsThunderBirdRoom).coords);
+
+        if (!ValidateShape(palace, shape))
+        {
+            //Debug.WriteLine("ValidateShape failed:\n" + GetLayoutDebug(shape, false, prepopulatedCoordinates));
+            palace.IsValid = false;
+            return palace;
+        }
 
         //Add rooms
         roomsByExitType = roomPool.CategorizeNormalRoomExits(true);
@@ -194,7 +219,7 @@ public abstract class ShapeFirstCoordinatePalaceGenerator() : CoordinatePalaceGe
         }
 
 
-        if (!AddSpecialRoomsByReplacement(palace, roomPool, r, props, GetItemRoomSelectionStrategy()))
+        if (!AddSpecialRoomsByReplacement(palace, roomPool, r, props, itemRoomSelector))
         {
             palace.IsValid = false;
             return palace;
@@ -270,7 +295,17 @@ public abstract class ShapeFirstCoordinatePalaceGenerator() : CoordinatePalaceGe
         return palaceNumber == 7 ? props.DarkLinkMinDistance : 0;
     }
 
-    public static string GetLayoutDebug(Dictionary<Coord, RoomExitType> walkGraph, bool includeCoordinateGrid = true)
+    protected virtual IEnumerable<RoomExitType> GetItemRoomShapes(RoomPool roomPool)
+    {
+        return roomPool.GetItemRoomShapes();
+    }
+
+    protected virtual bool ValidateShape(Palace palace, Dictionary<Coord, RoomExitType> palaceShape)
+    {
+        return true;
+    }
+
+    public static string GetLayoutDebug(Dictionary<Coord, RoomExitType> walkGraph, bool includeCoordinateGrid = true, List<Coord> prepopulatedCoordinates = null)
     {
         StringBuilder sb = new();
         if (includeCoordinateGrid)
@@ -300,14 +335,24 @@ public abstract class ShapeFirstCoordinatePalaceGenerator() : CoordinatePalaceGe
             sb.Append(includeCoordinateGrid ? y.ToString().PadLeft(3, ' ') : "   ");
             for (int x = -20; x <= 20; x++)
             {
-                if (!walkGraph.TryGetValue(new Coord(x, y), out RoomExitType room))
+                var coord = new Coord(x, y);
+                if (!walkGraph.TryGetValue(coord, out RoomExitType room))
                 {
                     sb.Append("   ");
                 }
                 else
                 {
                     sb.Append(room.ContainsLeft() ? '-' : ' ');
-                    sb.Append('X');
+
+                    if (prepopulatedCoordinates?.Contains(coord) ?? false)
+                    {
+                        sb.Append('P');
+                    }
+                    else
+                    {
+                        sb.Append('X');
+                    }
+
                     sb.Append(room.ContainsRight() ? '-' : ' ');
                 }
             }

--- a/RandomizerCore/Sidescroll/VanillaWeightedPalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/VanillaWeightedPalaceGenerator.cs
@@ -1,45 +1,49 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Z2Randomizer.RandomizerCore.Sidescroll;
 
 public class VanillaWeightedPalaceGenerator : RandomWalkCoordinatePalaceGenerator
 {
     private static readonly TableWeightedRandom<int>[] WeightedRandomDirections = [
+        // weights adjusted to make output somewhat statistically similar to vanilla values
+        // horizontal weights multiplied by 150%.
         new([ // Palace 1  (7x3 in vanilla)
-            (0, 7),  // left
-            (1, 3),  // down
-            (2, 3),  // up
-            (3, 7),  // right
+            (0, 21),  // left
+            (1, 6),  // down
+            (2, 6),  // up
+            (3, 21),  // right
         ]),
         new([ // Palace 2  (8x4 in vanilla)
-            (0, 2),  // left
+            (0, 3),  // left
             (1, 1),  // down
             (2, 1),  // up
-            (3, 2),  // right
-        ]),
-        new([ // Palace 3  (7x3 in vanilla)
-            (0, 7),  // left
-            (1, 3),  // down
-            (2, 3),  // up
-            (3, 7),  // right
-        ]),
-        new([ // Palace 4  (6x4 in vanilla)
-            (0, 3),  // left
-            (1, 2),  // down
-            (2, 2),  // up
             (3, 3),  // right
         ]),
+        new([ // Palace 3  (7x3 in vanilla)
+            (0, 21),  // left
+            (1, 6),  // down
+            (2, 6),  // up
+            (3, 21),  // right
+        ]),
+        new([ // Palace 4  (6x4 in vanilla)
+            (0, 9),  // left
+            (1, 4),  // down
+            (2, 4),  // up
+            (3, 9),  // right
+        ]),
         new([ // Palace 5  (7x5 in vanilla)
-            (0, 7),  // left
-            (1, 5),  // down
-            (2, 5),  // up
-            (3, 7),  // right
+            (0, 21),  // left
+            (1, 10),  // down
+            (2, 10),  // up
+            (3, 21),  // right
         ]),
         new([ // Palace 6  (10x6 in vanilla)
-            (0, 5),  // left
-            (1, 3),  // down
-            (2, 3),  // up
-            (3, 5),  // right
+            (0, 15),  // left
+            (1, 6),  // down
+            (2, 6),  // up
+            (3, 15),  // right
         ]),
         new([ // Great Palace  (10x13 in vanilla)
             (0, 10),  // left
@@ -90,5 +94,156 @@ public class VanillaWeightedPalaceGenerator : RandomWalkCoordinatePalaceGenerato
 
         double vanillaDistance = VanillaDistanceToBosses[palaceNumber - 1];
         return (int)Math.Round((double)(vanillaDistance * lengthScale));
+    }
+
+    public static Dictionary<Coord, int> MeasureDeadendPaths(Palace palace, Dictionary<Coord, RoomExitType> palaceShape)
+    {
+        List<Coord> importantCoords = [palace.Entrance!.coords, palace.BossRoom!.coords, ..palace.ItemRooms.Select(room => room.coords)];
+        SortedSet<Coord> allCoords = [.. palaceShape.Keys.Order()];
+
+        /// a map of coord -> distance  for each importantCoord
+        List<Dictionary<Coord, int>> distancesFromImportantCoord = [];
+        for (int a = 0; a < importantCoords.Count; a++)
+        {
+            Coord importantCoord = importantCoords[a];
+            Dictionary<Coord, int> distances = [];
+            Queue<(Coord coord, int dist)> queue = [];
+            queue.Enqueue((importantCoord, 0));
+            while (queue.Count > 0)
+            {
+                var (coord, dist) = queue.Dequeue();
+                if (distances.ContainsKey(coord)) { continue; }
+                distances[coord] = dist;
+                var shape = palaceShape[coord];
+                foreach (var neighbor in GetNeighborsAnyDirection(palaceShape, shape, coord))
+                {
+                    if (!distances.ContainsKey(neighbor))
+                    {
+                        queue.Enqueue((neighbor, dist + 1));
+                    }
+                }
+            }
+            distancesFromImportantCoord.Add(distances);
+        }
+
+        // find coords on the shortest paths between all important locations
+        SortedSet<Coord> optimalPathCoords = [];
+        for (int a = 0; a < importantCoords.Count; a++)
+        {
+            for (int b = a + 1; b < importantCoords.Count; b++)
+            {
+                var importantCoordA = importantCoords[a];
+                var importantCoordB = importantCoords[b];
+
+                var distFromImportantA = distancesFromImportantCoord[a];
+                var distFromImportantB = distancesFromImportantCoord[b];
+
+                if (!distFromImportantA.ContainsKey(importantCoordB))
+                {
+                    continue; // no path
+                }
+                int shortest = distFromImportantA[importantCoordB];
+
+                foreach (var coord in allCoords)
+                {
+                    if (distFromImportantA.TryGetValue(coord, out int distanceA) &&
+                        distFromImportantB.TryGetValue(coord, out int distanceB) &&
+                        distanceA + distanceB == shortest)
+                    {
+                        optimalPathCoords.Add(coord);
+                    }
+                }
+            }
+        }
+
+        // find all the distances from the optimal paths
+        // basically repeat the first step, except pre-fill all the
+        // optimal path coords with a cost of 0.
+        Dictionary<Coord, int> distancesToOptimalPath = [];
+        Queue<(Coord coord, int dist)> combinedQueue = new();
+        foreach (var coord in optimalPathCoords)
+        {
+            combinedQueue.Enqueue((coord, 0));
+        }
+        while (combinedQueue.Count > 0)
+        {
+            var (coord, dist) = combinedQueue.Dequeue();
+            if (distancesToOptimalPath.ContainsKey(coord)) { continue; }
+            distancesToOptimalPath[coord] = dist;
+            var shape = palaceShape[coord];
+            foreach (var neighbor in GetNeighborsAnyDirection(palaceShape, shape, coord))
+            {
+                if (!distancesToOptimalPath.ContainsKey(neighbor))
+                {
+                    combinedQueue.Enqueue((neighbor, dist + 1));
+                }
+            }
+        }
+        return distancesToOptimalPath;
+    }
+
+    /// iterator over all neighboring coords from `coord` according to `exitType`
+    public static IEnumerable<Coord> GetNeighborsOutgoing(RoomExitType exitType, Coord coord)
+    {
+        if (exitType.ContainsLeft())  { yield return coord with { X = coord.X - 1 }; }
+        if (exitType.ContainsRight()) { yield return coord with { X = coord.X + 1 }; }
+        if (exitType.ContainsUp())    { yield return coord with { Y = coord.Y + 1 }; }
+        if (exitType.ContainsDown())  { yield return coord with { Y = coord.Y - 1 }; }
+    }
+
+    /// iterator over all neighbors, with drop rooms being included both ways
+    public static IEnumerable<Coord> GetNeighborsAnyDirection(Dictionary<Coord, RoomExitType> shape, RoomExitType exitType, Coord coord)
+    {
+        if (exitType.ContainsLeft())  { yield return coord with { X = coord.X - 1 }; }
+        if (exitType.ContainsRight()) { yield return coord with { X = coord.X + 1 }; }
+
+        var upCoord = coord with { Y = coord.Y + 1 };
+        if (exitType.ContainsUp())
+        {
+            yield return upCoord;
+        }
+        else if (shape.TryGetValue(upCoord, out var upShape) && upShape.ContainsDown())
+        {
+            yield return upCoord;
+        }
+        if (exitType.ContainsDown()) { yield return coord with { Y = coord.Y - 1 }; }
+    }
+
+    /// Vanilla Z2 only has deadend item rooms. Lets try it.
+    protected override IEnumerable<RoomExitType> GetItemRoomShapes(RoomPool roomPool)
+    {
+        var shapesInPool = roomPool.GetItemRoomShapes();
+        return RoomExitTypeExtensions.DEADENDS.Intersect(shapesInPool);
+    }
+
+    protected override bool ValidateShape(Palace palace, Dictionary<Coord, RoomExitType> palaceShape)
+    {
+        // GP is too different from the other palaces. ignore for now
+        if (palace.Number == 7) { return true; }
+        int palaceSize = palaceShape.Count;
+
+        var shapeCounts = palaceShape.GroupBy(kvp => kvp.Value).ToDictionary(v => v.Key, v => v.Count());
+        var verticalCount = shapeCounts.GetValueOrDefault(RoomExitType.VERTICAL_PASSTHROUGH, 0);
+        var fourwayCount = shapeCounts.GetValueOrDefault(RoomExitType.FOUR_WAY, 0);
+        // disallow too many vertical rooms
+        if (verticalCount * 8 + fourwayCount * 6 > palaceSize)
+        {
+            return false;
+        }
+
+        var distancesToOptimalPath = MeasureDeadendPaths(palace, palaceShape);
+        var coords = distancesToOptimalPath.Keys;
+        double totalCost = 0.0;
+        double itemCount = palace.ItemRooms.Count;
+        foreach (var k in coords)
+        {
+            var v = distancesToOptimalPath[k];
+            // the number of items influences how strict we are about deadend paths
+            // (otherwise a 0 item palace would be an unfairly long linear path to the boss)
+            totalCost += Math.Pow(v, (itemCount * 0.5) + 1);
+        }
+        // get a ratio of deadend paths/palace size
+        double ratio = totalCost / palaceSize;
+        return ratio <= 6.0;
     }
 }


### PR DESCRIPTION
I'm posting this as a PR in case you want to review the changes to the palace generator super classes. (I have tested that the coordinate styles still generate reasonable palaces.)


- Added IItemRoomInShapeSelectionStrategy interface that is optional for a strategy to implement. ByShapeItemRoomSelectionStrategy implements it. There is some code duplication between the two methods in ByShapeItemRoomSelectionStrategy. I don't see a good way to fix this right now without adding a lot of abstraction, which would make it less readable.

The generated Vanilla Weighted shape is now validated more:
- We measure dead-end paths - paths that are not travel paths between the key points (entrance, item rooms and boss room). Using some math - that also takes into account palace size and the number of items - we reject some of the worse shapes. In my testing it seems to reject only about 1/5, which seems reasonable.
- Make the weights further more horizontal by 50% to try to match vanilla statistics a bit more.

- Includes a duplication fix for ByShapeItemRoomSelectionStrategy, since it used to compare references between cloned and non-cloned item rooms (which would never match).