### PR TITLE
Add Extra Loops palace style

### DIFF
--- a/RandomizerCore/EnumTypes.cs
+++ b/RandomizerCore/EnumTypes.cs
@@ -199,10 +199,8 @@ public enum PalaceStyle
 {
     [Description("Vanilla")]
     VANILLA,
-    [Description("Shuffled")]
+    [Description("Vanilla Shuffle")]
     SHUFFLED,
-    [Description("Reconstructed")]
-    RECONSTRUCTED,
     [Description("Sequential")]
     SEQUENTIAL,
     [Description("Random Walk")]
@@ -211,6 +209,10 @@ public enum PalaceStyle
     VANILLA_WEIGHTED,
     [Description("Tower")]
     TOWER,
+    [Description("Reconstructed")]
+    RECONSTRUCTED,
+    [Description("Loopy")]
+    RECONSTRUCTED_LOOPY,
     [Description("Chaos"), DefaultWeight(0)]
     CHAOS,
     [Description("Random"), Metastyle]

--- a/RandomizerCore/Sidescroll/Palace.cs
+++ b/RandomizerCore/Sidescroll/Palace.cs
@@ -185,6 +185,31 @@ public partial class Palace
         return false; // Boss room not found??
     }
 
+    public static int RoomDistance(Room room1, Room room2)
+    {
+        HashSet<Room> reachedRooms = [];
+        Queue<(Room, int)> roomsToCheck = [];
+        roomsToCheck.Enqueue((room1, 0));
+        while (roomsToCheck.Count > 0)
+        {
+            var (room, stepsToRoom) = roomsToCheck.Dequeue();
+            if (room == room2)
+            {
+                return stepsToRoom;
+            }
+
+            // This will return false if the room is already added
+            if (!reachedRooms.Add(room)) { continue; }
+
+            int stepsToNextRoom = stepsToRoom + 1;
+            if (room.Left != null) { roomsToCheck.Enqueue((room.Left, stepsToNextRoom)); }
+            if (room.Right != null) { roomsToCheck.Enqueue((room.Right, stepsToNextRoom)); }
+            if (room.Up != null) { roomsToCheck.Enqueue((room.Up, stepsToNextRoom)); }
+            if (room.Down != null) { roomsToCheck.Enqueue((room.Down, stepsToNextRoom)); }
+        }
+        return -1;
+    }
+
     /// same algorithm as BossRoomMinDistance except for shapes instead of rooms
     public static bool BossRoomMinDistanceShape(Dictionary<Coord, RoomExitType> shape, Coord bossRoom, int minSteps)
     {

--- a/RandomizerCore/Sidescroll/Palaces.cs
+++ b/RandomizerCore/Sidescroll/Palaces.cs
@@ -75,6 +75,7 @@ public class Palaces
                 PalaceStyle.VANILLA_WEIGHTED => new VanillaWeightedPalaceGenerator(),
                 PalaceStyle.TOWER => new TowerCoordinatePalaceGenerator(),
                 PalaceStyle.RECONSTRUCTED => new ReconstructedPalaceGenerator(ct),
+                PalaceStyle.RECONSTRUCTED_LOOPY => new ReconstructedLoopyPalaceGenerator(ct),
                 PalaceStyle.CHAOS => new ChaosPalaceGenerator(),
                 _ => throw new Exception("Unrecognized palace style while generating palaces")
             };

--- a/RandomizerCore/Sidescroll/ReconstructedLoopyPalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/ReconstructedLoopyPalaceGenerator.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Z2Randomizer.RandomizerCore.Sidescroll;
+
+public class ReconstructedLoopyPalaceGenerator(CancellationToken ct) : ReconstructedPalaceGenerator(ct)
+{
+    internal override Task<Palace> GeneratePalace(RandomizerProperties props, RoomPool rooms, Random r, int roomCount, int palaceNumber)
+    {
+        rooms.RemoveRooms(room => room.HasDrop);
+        rooms.RemoveRooms(room => !room.IsEntrance && !room.IsBossRoom && !room.HasItem
+                                  && RoomExitTypeExtensions.DEADENDS.Contains(room.CategorizeExits()));
+        return base.GeneratePalace(props, rooms, r, roomCount, palaceNumber);
+    }
+
+    public override void Consolidate(List<Room> openRooms)
+    {
+        Room[] openCopy = new Room[openRooms.Count];
+        openRooms.CopyTo(openCopy); // shallow copy
+        foreach (Room r2 in openCopy)
+        {
+            var furthestFirst = openRooms.OrderBy(room => -Palace.RoomDistance(r2, room));
+            foreach (Room r3 in furthestFirst)
+            {
+                if (r2 != r3 && openRooms.Contains(r2) && openRooms.Contains(r3))
+                {
+                    if (AttachToOpen(r2, r3, openRooms))
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/RandomizerCore/Sidescroll/ReconstructedPalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/ReconstructedPalaceGenerator.cs
@@ -307,7 +307,7 @@ public class ReconstructedPalaceGenerator(CancellationToken ct) : PalaceGenerato
         }
     }
 
-    public void Consolidate(List<Room> openRooms)
+    public virtual void Consolidate(List<Room> openRooms)
     {
         Room[] openCopy = new Room[openRooms.Count];
         openRooms.CopyTo(openCopy);
@@ -330,7 +330,7 @@ public class ReconstructedPalaceGenerator(CancellationToken ct) : PalaceGenerato
     /// <param name="room"></param> The room to be attached
     /// <param name="open"></param> The room onto which R is attached
     /// <returns>Whether or not the room was actually able to be attached.</returns>
-    private bool AttachToOpen(Room room, Room open, List<Room> openRooms)
+    protected bool AttachToOpen(Room room, Room open, List<Room> openRooms)
     {
         bool placed = false;
         //Right from open into r

--- a/RandomizerCore/Sidescroll/RoomExitType.cs
+++ b/RandomizerCore/Sidescroll/RoomExitType.cs
@@ -41,6 +41,7 @@ public enum RoomExitType
 public static class RoomExitTypeExtensions
 {
     public static RoomExitType[] ALL = Enum.GetValues(typeof(RoomExitType)).Cast<RoomExitType>().ToArray();
+    public static RoomExitType[] DEADENDS = [RoomExitType.DEADEND_EXIT_RIGHT, RoomExitType.DEADEND_EXIT_UP, RoomExitType.DEADEND_EXIT_LEFT, RoomExitType.DEADEND_EXIT_DOWN];
 
     public const int LEFT = 0b00010000;
     public const int DOWN = 0b00001000;


### PR DESCRIPTION
Based on Reconstructed with some twists:
- No regular dead-end rooms (not including item rooms)
- Loops pick rooms that are as far away as possible. This is to reduce the likelihood of long dead-end paths that would loop into themselves at the end. (It might still happen if there are very few open rooms.)
- No drop rooms

This is a small subclass to Reconstructed. I made this instead of having the option to remove drops from all styles, as drops are generally fun in the coordinate palaces.