### PR TITLE
Change material colors & add red UI indicator if spoiler is on

### DIFF
--- a/CrossPlatformUI/App.axaml
+++ b/CrossPlatformUI/App.axaml
@@ -7,11 +7,10 @@
              xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              xmlns:assists="clr-namespace:Material.Styles.Assists;assembly=Material.Styles"
              xmlns:behaviors="clr-namespace:CrossPlatformUI.Behaviors"
-             x:Class="CrossPlatformUI.App"
-             RequestedThemeVariant="Default">
+             x:Class="CrossPlatformUI.App">
              <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
     <Application.Styles>
-        <themes:MaterialTheme PrimaryColor="DeepPurple" SecondaryColor="LightBlue" />
+        <themes:MaterialTheme />
         <avalonia:MaterialIconStyles />
         <dialogHostAvalonia:DialogHostStyles />
         

--- a/CrossPlatformUI/App.axaml.cs
+++ b/CrossPlatformUI/App.axaml.cs
@@ -139,6 +139,8 @@ public sealed partial class App : Application // , IDisposable
         var state = !TransitionAssist.GetDisableTransitions(TopLevel!);
         TransitionAssist.SetDisableTransitions(TopLevel!, state);
 
+        ThemeHelper.SetTheme(main.RandomizerViewModel.ThemeVariantName);
+
         base.OnFrameworkInitializationCompleted();
     }
 

--- a/CrossPlatformUI/ThemeHelper.cs
+++ b/CrossPlatformUI/ThemeHelper.cs
@@ -1,0 +1,54 @@
+﻿using Avalonia.Media;
+using Material.Styles.Themes;
+
+namespace CrossPlatformUI;
+
+/// Material Avalonia's dynamic theming system leaves a lot to be desired.
+/// Probably base Avalonia is better for this & better documented.
+public class ThemeHelper
+{
+    private static readonly Theme DarkMaterialTheme;
+    private static readonly Theme LightMaterialTheme;
+
+    private static IBrush DarkNonStandardFlagEnabledBackground = SolidColorBrush.Parse("#80b10600");
+    private static IBrush LightNonStandardFlagEnabledBackground = SolidColorBrush.Parse("#d2b30000");
+
+    static ThemeHelper() {
+        DarkMaterialTheme = Theme.Create(Theme.Dark, Color.Parse("#ffbc33"), Color.Parse("#969696"));
+        DarkMaterialTheme.Paper = Color.Parse("#1a1a1a");
+
+        LightMaterialTheme = Theme.Create(Theme.Light, Color.Parse("#002a88"), Color.Parse("#696969"));
+    }
+
+    public static string SetTheme(string name)
+    {
+        var app = App.Current;
+        if (app == null)
+        {
+            return "Light";
+        }
+        var themeBootstrap = app.LocateMaterialTheme<MaterialTheme>();
+        switch (name)
+        {
+            case "Dark":
+                themeBootstrap.CurrentTheme = DarkMaterialTheme;
+                return "Dark";
+            case "Light":
+            default:
+                themeBootstrap.CurrentTheme = LightMaterialTheme;
+                return "Light";
+        }
+    }
+
+    public static IBrush GetFlagAlertBackgroundBrush(string theme, bool alert)
+    {
+        if (alert)
+        {
+            return theme == "Dark" ? DarkNonStandardFlagEnabledBackground : LightNonStandardFlagEnabledBackground;
+        }
+        else
+        {
+            return Brushes.Transparent;
+        }
+    }
+}

--- a/CrossPlatformUI/ViewModels/RandomizerViewModel.cs
+++ b/CrossPlatformUI/ViewModels/RandomizerViewModel.cs
@@ -8,8 +8,10 @@ using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
+using Material.Colors;
 using Avalonia.Controls;
-using Avalonia.Styling;
+using Avalonia.Media;
+using Material.Styles.Themes;
 using ReactiveUI;
 using ReactiveUI.Validation.Extensions;
 using ReactiveUI.Validation.Helpers;
@@ -56,22 +58,17 @@ public class RandomizerViewModel : ReactiveValidationObject, IRoutableViewModel,
         }
     }
 
-    private string themeVariantName = "";
+    [JsonIgnore]
+    public BehaviorSubject<string> ThemeVariantSubject = new("");
     public string ThemeVariantName 
     {
         get
         {
-            return themeVariantName;
+            return ThemeVariantSubject.Value;
         }
         set
         {
-            App.Current!.RequestedThemeVariant = value switch
-            {
-                "Light" => ThemeVariant.Light,
-                "Dark" => ThemeVariant.Dark,
-                _ => ThemeVariant.Default
-            };
-            themeVariantName = value;
+            ThemeVariantSubject.OnNext(ThemeHelper.SetTheme(value));
         }
     }
     private int currentTabIndex;
@@ -94,6 +91,7 @@ public class RandomizerViewModel : ReactiveValidationObject, IRoutableViewModel,
         BiomesViewModel = new(Main);
         PalacesViewModel = new(Main);
         ItemsViewModel = new(Main);
+        HintsViewModel = new(Main, this);
         CustomizeViewModel = new(Main);
         Activator = new ViewModelActivator();
 
@@ -132,15 +130,14 @@ public class RandomizerViewModel : ReactiveValidationObject, IRoutableViewModel,
 
         ToggleTheme = ReactiveCommand.Create(() =>
         {
-            if(App.Current!.ActualThemeVariant == ThemeVariant.Dark)
+            if(ThemeVariantName == "Dark")
             {
-                App.Current!.RequestedThemeVariant = ThemeVariant.Light;
+                ThemeVariantName = "Light";
             }
-            else if (App.Current!.ActualThemeVariant == ThemeVariant.Light)
+            else
             {
-                App.Current!.RequestedThemeVariant = ThemeVariant.Dark;
+                ThemeVariantName = "Dark";
             }
-            ThemeVariantName = App.Current.RequestedThemeVariant?.Key.ToString() ?? "Default";
         });
 
         var seedValidObservable = this.WhenAnyValue(x => x.Main.Config.Seed, seed => !string.IsNullOrWhiteSpace(seed));
@@ -318,6 +315,7 @@ public class RandomizerViewModel : ReactiveValidationObject, IRoutableViewModel,
     public BiomesViewModel BiomesViewModel { get; }
     public PalacesViewModel PalacesViewModel { get; }
     public ItemsViewModel ItemsViewModel { get; }
+    public HintsViewModel HintsViewModel { get; }
     public CustomizeViewModel CustomizeViewModel { get; }
     
     [JsonIgnore]

--- a/CrossPlatformUI/ViewModels/Tabs/HintsViewModel.cs
+++ b/CrossPlatformUI/ViewModels/Tabs/HintsViewModel.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using Avalonia.Media;
+using ReactiveUI;
+
+namespace CrossPlatformUI.ViewModels.Tabs;
+
+[RequiresUnreferencedCode("ReactiveUI uses reflection")]
+public class HintsViewModel : ReactiveObject, IActivatableViewModel
+{
+    public ViewModelActivator Activator { get; }
+    public MainViewModel Main { get; }
+    public IObservable<IBrush> HeaderBackgroundObservable { get; }
+
+    public HintsViewModel(MainViewModel main, RandomizerViewModel randomizerViewModel)
+    {
+        Main = main;
+        Activator = new();
+
+        var alertFlags = Main.FlagsChanged
+            .Select(_ => Main.Config.GenerateSpoiler)
+            .DistinctUntilChanged();
+
+        HeaderBackgroundObservable = randomizerViewModel.ThemeVariantSubject.CombineLatest(alertFlags)
+            .Select(pair => ThemeHelper.GetFlagAlertBackgroundBrush(pair.First, pair.Second));
+
+        this.WhenActivated(OnActivate);
+    }
+
+    internal void OnActivate(CompositeDisposable disposables)
+    {
+    }
+}

--- a/CrossPlatformUI/Views/RandomizerView.axaml
+++ b/CrossPlatformUI/Views/RandomizerView.axaml
@@ -202,8 +202,8 @@
             <TabItem Header="Drops">
                 <tabs:DropsView DataContext="{Binding Main}"/>
             </TabItem>
-            <TabItem Header="Hints">
-                <tabs:HintsView DataContext="{Binding Main}"/>
+            <TabItem Header="Hints" Background="{Binding HintsViewModel.HeaderBackgroundObservable^}">
+                <tabs:HintsView DataContext="{Binding HintsViewModel}"/>
             </TabItem>
             <TabItem Header="Customize">
                 <tabs:CustomizeView DataContext="{Binding CustomizeViewModel}" />

--- a/CrossPlatformUI/Views/Tabs/HintsView.axaml
+++ b/CrossPlatformUI/Views/Tabs/HintsView.axaml
@@ -6,10 +6,11 @@
              xmlns:rc="clr-namespace:Z2Randomizer.RandomizerCore;assembly=RandomizerCore"
              xmlns:ui="clr-namespace:CrossPlatformUI"
              xmlns:vm="clr-namespace:CrossPlatformUI.ViewModels"
+             xmlns:vmt="clr-namespace:CrossPlatformUI.ViewModels.Tabs"
              xmlns:lang="clr-namespace:Z2Randomizer.CrossPlatformUI.Lang"
              mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="600"
-             x:DataType="vm:MainViewModel"
-             x:Class="CrossPlatformUI.Views.Tabs.HintsView">
+             x:Class="CrossPlatformUI.Views.Tabs.HintsView"
+             x:DataType="vmt:HintsViewModel">
     <Grid ColumnDefinitions="*, *">
         <StackPanel Grid.Column="0">
             <HyperlinkButton
@@ -24,36 +25,35 @@
 
             <CheckBox
                 IsThreeState="True"
-                IsChecked="{Binding Config.EnableHelpfulHints}"
+                IsChecked="{Binding Main.Config.EnableHelpfulHints}"
                 Content="Enable Helpful Hints"
             >
                 <ToolTip.Tip><TextBlock Text="{x:Static lang:Resources.EnableHelpfulHintsToolTip}"/></ToolTip.Tip>
             </CheckBox>
             <CheckBox
                 IsThreeState="True"
-                IsChecked="{Binding Config.EnableSpellItemHints}"
+                IsChecked="{Binding Main.Config.EnableSpellItemHints}"
                 Content="Enable Spell Item Hints"
             >
                 <ToolTip.Tip><TextBlock Text="{x:Static lang:Resources.EnableSpellItemHintsToolTip}"/></ToolTip.Tip>
             </CheckBox>
             <CheckBox
                 IsThreeState="True"
-                IsChecked="{Binding Config.EnableTownNameHints}"
+                IsChecked="{Binding Main.Config.EnableTownNameHints}"
                 Content="Enable Town Name Hints"
             >
                 <ToolTip.Tip><TextBlock Text="{x:Static lang:Resources.EnableTownNameHintsToolTip}"/></ToolTip.Tip>
             </CheckBox>
         </StackPanel>
         <StackPanel Grid.Column="1">
-            <CheckBox
-                IsThreeState="False"
-                IsChecked="{Binding Config.GenerateSpoiler}"
-                Content="Generate Spoiler"
-            >
+            <CheckBox IsChecked="{Binding Main.Config.GenerateSpoiler}"
+                      Margin="14,4,4,4" Padding="0,4,0,4"
+                      Background="{Binding HeaderBackgroundObservable^}"
+                      Content="Generate Spoiler">
                 <ToolTip.Tip><TextBlock Text="{x:Static lang:Resources.GenerateSpoilerToolTip}"/></ToolTip.Tip>
             </CheckBox>
             <CheckBox
-                IsChecked="{Binding Config.RevealWalkthroughWalls}"
+                IsChecked="{Binding Main.Config.RevealWalkthroughWalls}"
                 Content="Reveal Walkthrough Walls"
             >
                 <ToolTip.Tip><TextBlock Text="{x:Static lang:Resources.RevealWalkthroughWallsToolTip}"/></ToolTip.Tip>


### PR DESCRIPTION
- Mostly the background was too bright (More important for readability)
- Trying out new (Triforce-like) orange primary color for dark mode
- Trying out dark blue primary color for light mode

After many failed attempts at setting this in the .axaml, this is just set in the code. (Who decided we should use Material.Avalonia?)


Screenshot of dark mode with spoiler on:
<img width="1032" height="782" alt="image" src="https://github.com/user-attachments/assets/26cfad84-afdd-4dbd-b405-6d14b0666f47" />
