### PR TITLE
[5.2] Create our own Random class using the xoshiro256 algorithm

### DIFF
--- a/CommandLine/Program.cs
+++ b/CommandLine/Program.cs
@@ -67,7 +67,7 @@ public class Program
 
         if (!Seed.HasValue) 
         {
-            var r = new Random();
+            var r = new System.Random();
             Seed = r.Next(1000000000);
         } 
         configuration!.Seed = Seed.Value.ToString();

--- a/CrossPlatformUI/ViewModels/RandomizerViewModel.cs
+++ b/CrossPlatformUI/ViewModels/RandomizerViewModel.cs
@@ -98,7 +98,7 @@ public class RandomizerViewModel : ReactiveValidationObject, IRoutableViewModel,
 
         RerollSeed = ReactiveCommand.Create(() =>
         {
-            Main.Config.Seed = new Random().Next(0, 999999999).ToString();
+            Main.Config.Seed = new System.Random().Next(0, 999999999).ToString();
         });
         
         LoadPreset = ReactiveCommand.Create<RandomizerConfiguration>(config =>

--- a/RandomizerCore/CharacterSprite.cs
+++ b/RandomizerCore/CharacterSprite.cs
@@ -56,7 +56,7 @@ public class CharacterSprite
 
     public static CharacterSprite Random(CharacterSprite[] options)
     {
-        Random random = new Random();
+        System.Random random = new();
         return options[random.Next(options.Length - 1)];
     }
 };

--- a/RandomizerCore/Hyrule.cs
+++ b/RandomizerCore/Hyrule.cs
@@ -1,18 +1,16 @@
-﻿using DynamicData;
-using FtRandoLib.Importer;
-using js65;
-using NLog;
-using System;
+﻿using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using NLog;
+using js65;
+using FtRandoLib.Importer;
 using Z2Randomizer.RandomizerCore.Enemy;
 using Z2Randomizer.RandomizerCore.Overworld;
 using Z2Randomizer.RandomizerCore.Sidescroll;
@@ -174,7 +172,7 @@ public class Hyrule
     */
 
     public ROM ROMData { get; set; }
-    public Random r { get; set; }
+    public RandomizerCore.Random r { get; set; }
     public string Flags { get; private set; }
     public int SeedHash { get; private set; }
     public RandomizerProperties Props
@@ -1282,7 +1280,7 @@ public class Hyrule
         try
         {
             ROM testRom = new(ROMData);
-            Random testRng = new Random();
+            Random testRng = new(SeedHash);
             //This continues to get worse, the text is based on the palaces and asm patched, so it needs to
             //be tested here, but we don't actually know what they will be until later, for now i'm just
             //testing with the vanilla text, but this could be an issue down the line.

--- a/RandomizerCore/Hyrule.cs
+++ b/RandomizerCore/Hyrule.cs
@@ -1,18 +1,16 @@
-﻿using DynamicData;
-using FtRandoLib.Importer;
-using js65;
-using NLog;
-using System;
+﻿using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using NLog;
+using js65;
+using FtRandoLib.Importer;
 using Z2Randomizer.RandomizerCore.Enemy;
 using Z2Randomizer.RandomizerCore.Overworld;
 using Z2Randomizer.RandomizerCore.Sidescroll;
@@ -172,7 +170,7 @@ public class Hyrule
     */
 
     public ROM ROMData { get; set; }
-    public Random r { get; set; }
+    public RandomizerCore.Random r { get; set; }
     public string Flags { get; private set; }
     public int SeedHash { get; private set; }
     public RandomizerProperties Props
@@ -1280,7 +1278,7 @@ public class Hyrule
         try
         {
             ROM testRom = new(ROMData);
-            Random testRng = new Random();
+            Random testRng = new(SeedHash);
             //This continues to get worse, the text is based on the palaces and asm patched, so it needs to
             //be tested here, but we don't actually know what they will be until later, for now i'm just
             //testing with the vanilla text, but this could be an issue down the line.

--- a/RandomizerCore/Music.cs
+++ b/RandomizerCore/Music.cs
@@ -160,7 +160,7 @@ internal class MusicRandomizer
         bool safeOnly)
     {
         _hyrule = hyrule;
-        _shuffler = new RandomShuffler(new Random(seed));
+        _shuffler = new RandomShuffler(new System.Random(seed));
         _rom = _hyrule.ROMData.GetBytes(0, ROM.RomSize);
         _romAccess = new(_rom);
         _jsonLibPaths = new(jsonLibPaths);

--- a/RandomizerCore/ROM.cs
+++ b/RandomizerCore/ROM.cs
@@ -633,7 +633,7 @@ TitleEnd:
 
         static int RandomUniqueColor(params int?[] forbiddenColors)
         {
-            Random random = new Random();
+            System.Random random = new();
             int color;
             do
             {
@@ -695,7 +695,7 @@ TitleEnd:
     {
         if (beamSprite == BeamSprites.RANDOM)
         {
-            Random r2 = new();
+            System.Random r2 = new();
             beamSprite = (BeamSprites)r2.Next(Enum.GetValues(typeof(BeamSprites)).Length - 1);
         }
 

--- a/RandomizerCore/Random.cs
+++ b/RandomizerCore/Random.cs
@@ -1,0 +1,307 @@
+﻿// Portions of this file are derived from the .NET runtime implementation of System.Random.
+// https://source.dot.net/#System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/Random.cs
+// https://source.dot.net/#System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/Random.ImplBase.cs
+// https://source.dot.net/#System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/Random.Xoshiro256StarStarImpl.cs
+// Copyright (c) .NET Foundation and Contributors.
+// Licensed under the MIT License.
+//
+// Additional algorithms:
+// - xoshiro256** (Public Domain) http://prng.di.unimi.it/xoshiro256starstar.c
+// - SplitMix64 (Public Domain) https://xorshift.di.unimi.it/splitmix64.c
+
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Z2Randomizer.RandomizerCore;
+
+public class Random
+{
+    private ulong _s0, _s1, _s2, _s3;
+
+    public Random(long seed)
+    {
+        var splitMix = new SplitMix64((ulong)seed);
+        do
+        {
+            _s0 = splitMix.Next();
+            _s1 = splitMix.Next();
+            _s2 = splitMix.Next();
+            _s3 = splitMix.Next();
+        } while ((_s0 | _s1 | _s2 | _s3) == 0); // at least one value must be non-zero
+    }
+
+    public System.String GetState()
+    {
+        System.Span<byte> bytes = stackalloc byte[32];
+        MemoryMarshal.Write(bytes, in _s0);
+        MemoryMarshal.Write(bytes.Slice(8), in _s1);
+        MemoryMarshal.Write(bytes.Slice(16), in _s2);
+        MemoryMarshal.Write(bytes.Slice(24), in _s3);
+        return System.Convert.ToBase64String(bytes);
+    }
+
+    public void SetState(System.String state)
+    {
+        byte[] bytes = System.Convert.FromBase64String(state);
+
+        if (bytes.Length != 32)
+        {
+            throw new System.ArgumentException("Invalid RNG state.", nameof(state));
+        }
+
+        System.ReadOnlySpan<byte> span = bytes;
+
+        _s0 = MemoryMarshal.Read<ulong>(span);
+        _s1 = MemoryMarshal.Read<ulong>(span[8..]);
+        _s2 = MemoryMarshal.Read<ulong>(span[16..]);
+        _s3 = MemoryMarshal.Read<ulong>(span[24..]);
+
+        if ((_s0 | _s1 | _s2 | _s3) == 0)
+        {
+            throw new System.ArgumentException("Invalid RNG state (all zero).", nameof(state));
+        }
+    }
+
+    /// <summary>Produces a value in the range [0, ulong.MaxValue].</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal ulong NextUInt64()
+    {
+        ulong s0 = _s0, s1 = _s1, s2 = _s2, s3 = _s3;
+
+        ulong result = BitOperations.RotateLeft(s1 * 5, 7) * 9;
+
+        ulong t = s1 << 17;
+
+        s2 ^= s0;
+        s3 ^= s1;
+        s1 ^= s2;
+        s0 ^= s3;
+
+        s2 ^= t;
+        s3 = BitOperations.RotateLeft(s3, 45);
+
+        _s0 = s0;
+        _s1 = s1;
+        _s2 = s2;
+        _s3 = s3;
+
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal ulong NextUInt64(ulong maxValue)
+    {
+        ulong randomProduct = System.Math.BigMul(maxValue, NextUInt64(), out ulong lowPart);
+
+        if (lowPart < maxValue)
+        {
+            ulong remainder = (0ul - maxValue) % maxValue;
+
+            while (lowPart < remainder)
+            {
+                randomProduct = System.Math.BigMul(maxValue, NextUInt64(), out lowPart);
+            }
+        }
+
+        return randomProduct;
+    }
+
+    /// <summary>Produces a value in the range [0, uint.MaxValue].</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)] // small-ish hot path used by very few call sites
+    internal uint NextUInt32()
+    {
+        return (uint)(NextUInt64() >> 32);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal uint NextUInt32(uint maxValue)
+    {
+        ulong randomProduct = (ulong)maxValue * NextUInt32();
+        uint lowPart = (uint)randomProduct;
+
+        if (lowPart < maxValue)
+        {
+            uint remainder = (0u - maxValue) % maxValue;
+
+            while (lowPart < remainder)
+            {
+                randomProduct = (ulong)maxValue * NextUInt32();
+                lowPart = (uint)randomProduct;
+            }
+        }
+
+        return (uint)(randomProduct >> 32);
+    }
+
+    public int Next()
+    {
+        while (true)
+        {
+            // Get top 31 bits to get a value in the range [0, int.MaxValue], but try again
+            // if the value is actually int.MaxValue, as the method is defined to return a value
+            // in the range [0, int.MaxValue).
+            ulong result = NextUInt64() >> 33;
+            if (result != int.MaxValue)
+            {
+                return (int)result;
+            }
+        }
+    }
+
+    public int Next(int maxValue)
+    {
+        Debug.Assert(maxValue >= 0);
+
+        return (int)NextUInt32((uint)maxValue);
+    }
+
+    public int Next(int minValue, int maxValue)
+    {
+        Debug.Assert(minValue <= maxValue);
+
+        return (int)NextUInt32((uint)(maxValue - minValue)) + minValue;
+    }
+
+    public long NextInt64()
+    {
+        while (true)
+        {
+            // Get top 63 bits to get a value in the range [0, long.MaxValue], but try again
+            // if the value is actually long.MaxValue, as the method is defined to return a value
+            // in the range [0, long.MaxValue).
+            ulong result = NextUInt64() >> 1;
+            if (result != long.MaxValue)
+            {
+                return (long)result;
+            }
+        }
+    }
+
+    public long NextInt64(long maxValue)
+    {
+        Debug.Assert(maxValue >= 0);
+
+        return (long)NextUInt64((ulong)maxValue);
+    }
+
+    public long NextInt64(long minValue, long maxValue)
+    {
+        Debug.Assert(minValue <= maxValue);
+
+        return (long)NextUInt64((ulong)(maxValue - minValue)) + minValue;
+    }
+
+    public void NextBytes(System.Span<byte> buffer)
+    {
+        while (buffer.Length >= sizeof(ulong))
+        {
+            ulong value = NextUInt64();
+            MemoryMarshal.Write(buffer, in value);
+            buffer = buffer.Slice(sizeof(ulong));
+        }
+
+        if (!buffer.IsEmpty)
+        {
+            ulong value = NextUInt64();
+            System.Span<byte> buf = stackalloc byte[sizeof(ulong)];
+            MemoryMarshal.Write(buf, in value);
+            buf[..buffer.Length].CopyTo(buffer);
+        }
+    }
+
+    public double NextDouble()
+    {
+        // As described in http://prng.di.unimi.it/:
+        // "A standard double (64-bit) floating-point number in IEEE floating point format has 52 bits of significand,
+        //  plus an implicit bit at the left of the significand. Thus, the representation can actually store numbers with
+        //  53 significant binary digits. Because of this fact, in C99 a 64-bit unsigned integer x should be converted to
+        //  a 64-bit double using the expression
+        //  (x >> 11) * 0x1.0p-53"
+        return (NextUInt64() >> 11) * (1.0 / (1ul << 53));
+    }
+
+    /// <summary>
+    ///   Fills the elements of a specified span with items chosen at random from the provided set of choices.
+    /// </summary>
+    /// <param name="choices">The items to use to populate the span.</param>
+    /// <param name="destination">The span to be filled with items.</param>
+    /// <typeparam name="T">The type of span.</typeparam>
+    /// <exception cref="ArgumentException"><paramref name="choices" /> is empty.</exception>
+    /// <remarks>
+    ///   The method uses <see cref="Next(int)" /> to select items randomly from <paramref name="choices" />
+    ///   by index and populate <paramref name="destination" />.
+    /// </remarks>
+    public void GetItems<T>(System.ReadOnlySpan<T> choices, System.Span<T> destination)
+    {
+        if (choices.IsEmpty)
+        {
+            throw new System.ArgumentException();
+        }
+        // Simple fallback: get each item individually, generating a new random Int32 for each
+        // item. This is slower than the above, but it works for all types and sizes of choices.
+        for (int i = 0; i < destination.Length; i++)
+        {
+            destination[i] = choices[Next(choices.Length)];
+        }
+    }
+
+    /// <summary>
+    ///   Creates an array populated with items chosen at random from the provided set of choices.
+    /// </summary>
+    /// <param name="choices">The items to use to populate the array.</param>
+    /// <param name="length">The length of array to return.</param>
+    /// <typeparam name="T">The type of array.</typeparam>
+    /// <returns>An array populated with random items.</returns>
+    /// <exception cref="ArgumentException"><paramref name="choices" /> is empty.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///   <paramref name="length" /> is not zero or a positive number.
+    /// </exception>
+    /// <remarks>
+    ///   The method uses <see cref="Next(int)" /> to select items randomly from <paramref name="choices" />
+    ///   by index. This is used to populate a newly-created array.
+    /// </remarks>
+    public T[] GetItems<T>(System.ReadOnlySpan<T> choices, int length)
+    {
+        System.ArgumentOutOfRangeException.ThrowIfNegative(length);
+        T[] items = new T[length];
+        GetItems(choices, new System.Span<T>(items));
+        return items;
+    }
+
+    /// <summary>
+    ///   Performs an in-place shuffle of a span.
+    /// </summary>
+    /// <param name="values">The span to shuffle.</param>
+    /// <typeparam name="T">The type of span.</typeparam>
+    /// <remarks>
+    ///   This method uses <see cref="Next(int, int)" /> to choose values for shuffling.
+    ///   This method is an O(n) operation.
+    /// </remarks>
+    public void Shuffle<T>(System.Span<T> values)
+    {
+        for (int i = 0; i < values.Length - 1; i++)
+        {
+            int j = Next(i, values.Length);
+
+            // The i != j check is excluded intentionally.
+            // Microbenchmarks show that the mispredicted branches cost more than the redundant read/write for small value types.
+            // Since large value types are uncommon in shuffle scenarios, the trade-off favors removing the branch.
+            T temp = values[i];
+            values[i] = values[j];
+            values[j] = temp;
+        }
+    }
+
+    private class SplitMix64(ulong seed)
+    {
+        public ulong Next()
+        {
+            ulong z = (seed += 0x9e3779b97f4a7c15);
+            z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9;
+            z = (z ^ (z >> 27)) * 0x94d049bb133111eb;
+            return z ^ (z >> 31);
+        }
+    }
+}

--- a/RandomizerCore/RandomizerCore.csproj
+++ b/RandomizerCore/RandomizerCore.csproj
@@ -13,6 +13,7 @@
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <DefineConstants Condition="'$(Configuration)' == 'Unsafe Debug'">UNSAFE_DEBUG;$(DefineConstants)</DefineConstants>
     <PublishTrimmed>true</PublishTrimmed>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Statistics/Statistics.cs
+++ b/Statistics/Statistics.cs
@@ -35,7 +35,7 @@ class Statistics
         StatisticsDbContext dbContext = new StatisticsDbContext(DB_PATH);
 
         RandomizerConfiguration config = new RandomizerConfiguration(FLAGS);
-        Random random = new Random(2);
+        System.Random random = new(2);
         Hyrule.NewAssemblerFn createAsm = (opts, debug) => new DesktopJsEngine(opts, debug);
         var roomsJson = Util.ReadAllTextFromFile("PalaceRooms.json");
         var customJson = config.UseCustomRooms ? Util.ReadAllTextFromFile("CustomRooms.json") : null;

--- a/Tests/ShuffleBagTests.cs
+++ b/Tests/ShuffleBagTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Z2Randomizer.RandomizerCore;
+using Random = Z2Randomizer.RandomizerCore.Random;
 
 namespace Tests;
 


### PR DESCRIPTION
I did not find a library that satisfied all requirements, so I just made a variant of existing open source (MIT or Public Domain) code.


- This same algorithm can be chosen by .NET internally (and is Public Domain), but there is no guarantee that this is the case. By having a specific implementation, we can guarantee deterministic output.
- This gives access to the state of the Random object at any point via GetState and SetState methods that use Base64 strings. This should allow us to capture the RNG state if an error occurs and reproduce it as needed.
- This Random class exists in the RandomizerCore package and will take precedence when working inside this package. It is not a subclass of the System.Random class, so trying to use the wrong class somewhere will just not compile. It has no constructor without a seed. When we don't need to specify a seed, we can still use System.Random (as that implies we don't care about deterministic output).

Implements #395