### PR TITLE
Rework Sprite Palette Shuffle to be a customize (non-flag) setting

### DIFF
--- a/CrossPlatformUI/Lang/Resources.resx
+++ b/CrossPlatformUI/Lang/Resources.resx
@@ -236,8 +236,9 @@ amount.</value>
 immune in each group is the same as the number in that group that are immune in vanilla.</value>
 	</data>
 	<data name="ShuffleSpritePalettesToolTip" xml:space="preserve">
-<value>Randomizes the colors each of the enemies are. This could cause which enemies are visible
-in the dark to change.</value>
+<value>Randomizes the color palettes of enemies and NPCs. Health bar color is also randomized.
+
+Does *not* change what is visible in caves without a candle.</value>
 	</data>
 	<data name="EnemyExperienceDropsToolTip" xml:space="preserve">
 <value>Controls how much experience enemies give.

--- a/CrossPlatformUI/Views/Tabs/CustomizeView.axaml
+++ b/CrossPlatformUI/Views/Tabs/CustomizeView.axaml
@@ -52,11 +52,13 @@
                 <ToolTip.Tip><TextBlock Text="{x:Static lang:Resources.BeepFrequencyToolTip}"/></ToolTip.Tip>
             </ComboBox>
 
-            <CheckBox
-                IsChecked="{Binding UseCommunityText}"
-                Content="Use Community Text"
-            >
+            <CheckBox IsChecked="{Binding UseCommunityText}"
+                      Content="Use Community Text">
                 <ToolTip.Tip><TextBlock Text="{x:Static lang:Resources.UseCommunityTextToolTip}"/></ToolTip.Tip>
+            </CheckBox>
+            <CheckBox IsChecked="{Binding ShuffleSpritePalettes}"
+                      Content="Shuffle Sprite Palettes">
+                <ToolTip.Tip><TextBlock Text="{x:Static lang:Resources.ShuffleSpritePalettesToolTip}"/></ToolTip.Tip>
             </CheckBox>
 
             <Separator/>

--- a/CrossPlatformUI/Views/Tabs/EnemiesView.axaml
+++ b/CrossPlatformUI/Views/Tabs/EnemiesView.axaml
@@ -119,10 +119,6 @@
                 <ToolTip.Tip><TextBlock Text="{x:Static lang:Resources.EnemyExperienceDropsToolTip}"/></ToolTip.Tip>
             </ComboBox>
 
-            <CheckBox IsChecked="{Binding Config.ShuffleSpritePalettes}"
-                      Content="Shuffle Sprite Palettes">
-                <ToolTip.Tip><TextBlock Text="{x:Static lang:Resources.ShuffleSpritePalettesToolTip}"/></ToolTip.Tip>
-            </CheckBox>
             <CheckBox IsChecked="{Binding Config.RandomizeKnockback}"
                       Content="Randomize Knockback">
                 <ToolTip.Tip><TextBlock Text="{x:Static lang:Resources.RandomizeKnockbackToolTip}"/></ToolTip.Tip>

--- a/RandomizerCore/Hyrule.cs
+++ b/RandomizerCore/Hyrule.cs
@@ -2531,32 +2531,21 @@ public class Hyrule
 
         if (props.ShuffleEnemyPalettes)
         {
-            List<int> doubleLocs = [0x40b4, 0x80b4, 0x100b4, 0x100b8, 0x100bc, 0x140b4, 0x140b8, 0x140bc];
-            List<int> singleLocs = [0x40b8, 0x40bc, 0x80b8, 0x80bc];
+            Random customizationRng = new Random(SeedHash);
+            RerollPaletteTable(RomMap.WEST_PALETTE_TABLE, customizationRng);
+            RerollPaletteTable(RomMap.EAST_PALETTE_TABLE, customizationRng);
+            RerollPaletteTable(RomMap.TOWN_PALETTE_TABLE, customizationRng);
+            RerollPaletteTable(RomMap.PALACE_PALETTE_TABLE_MAJOR, customizationRng);
+            RerollPaletteTable(RomMap.GP_PALETTE_TABLE_MAJOR, customizationRng);
 
-            foreach (int i in doubleLocs)
-            {
-                int low = r.Next(12) + 1;
-                int high = (r.Next(2) + 1) * 16;
-                int color = high + low;
-                ROMData.Put(i, (byte)color);
-                ROMData.Put(i + 16, (byte)color);
-                ROMData.Put(i - 1, (byte)(color - 15));
-                ROMData.Put(i + 16 - 1, (byte)(color - 15));
-            }
-            foreach (int i in singleLocs)
-            {
-                int low = r.Next(13);
-                int high = (r.Next(3)) * 16;
-                int color = high + low;
-                ROMData.Put(i, (byte)color);
-                ROMData.Put(i + 16, (byte)color);
-                ROMData.Put(i + 16 - 1, (byte)(color - 15));
-            }
+            /*
+            lets no longer shuffle orange/red/blue bits for enemies, it changes
+            what is visible in the dark and also doesn't add enough to be worth it imo.
+            I also prefer if we can have the palette shuffle as a customize (non-flag) option.
 
-            for (int i = 0x54e8; i < 0x5508; i++)
+            for (int i = RomMap.WEST_ENEMY_STATS_TABLE + 0x3; i < RomMap.WEST_ENEMY_STATS_TABLE + 0x23; i++)
             {
-                if (i != 0x54f8)
+                if (i != RomMap.WEST_ENEMY_STATS_TABLE + 0x13) // skip elevator
                 {
                     int b = ROMData.GetByte(i);
                     int p = b & 0x3F;
@@ -2565,7 +2554,6 @@ public class Hyrule
                     ROMData.Put(i, (byte)(n + p));
                 }
             }
-
             for (int i = 0x94e8; i < 0x9508; i++)
             {
                 if (i != 0x94f8)
@@ -2610,6 +2598,7 @@ public class Hyrule
                     ROMData.Put(i, (byte)(n + p));
                 }
             }
+            */
         }
 
         //WRITE UPDATES TO WIZARD/QUEST COLLECTABLES HERE
@@ -2824,6 +2813,104 @@ public class Hyrule
         for (int i = 0; i < 16; i++)
         {
             ROMData.Put(ROM.ChrRomOffset + 0x12CC0 + i, ROMData.GetByte(ROM.ChrRomOffset + 0x14CC0 + i));
+        }
+    }
+
+    private void RerollPaletteTable(int paletteTableAddr, Random r)
+    {
+        byte dark, middle, light;
+
+        // we are NOT rolling the white color for magic/interface that should match the orange sprite light
+        // (white looks fine with all 2 other sprite colors anyway)
+        // int[] magicBgColorAddr = [paletteTableAddr + 0x01, paletteTableAddr + 0x11];
+        // we ARE rolling the red sprite and matching the red tile color for the life bars to it
+        // (it would limit the palette a lot if the red color has to stay red)
+        List<int> lifeBgColorAddr = [.. Enumerable.Range(0, 9).Select(i => paletteTableAddr + 0x10 * i + 0x03)];
+        List<int> orangeSpriteColorAddr = [paletteTableAddr + 0x94];
+        List<int> redSpriteColorAddr = [paletteTableAddr + 0x98];
+        List<int> blueSpriteColorAddr = [paletteTableAddr + 0x9c];
+
+        List<int> darkRangeFull = [.. Enumerable.Range(0x01, 12), .. Enumerable.Range(0x11, 13), 0x2d];
+        // we make the life color range slightly narrower, to not make the HUD look too awful
+        List<int> darkRangeLife = [.. Enumerable.Range(0x04, 3), .. Enumerable.Range(0x13, 5), .. Enumerable.Range(0x19, 4)];
+        // brighter dark colors do not look good in towns
+        List<int> darkRangeTown = [.. Enumerable.Range(0x01, 12), 0x1d];
+
+        if (paletteTableAddr == RomMap.PALACE_PALETTE_TABLE_MAJOR)
+        {
+            orangeSpriteColorAddr.AddRange(Enumerable.Range(0, 3).Select(i => paletteTableAddr + 0xa4 + 0x10 * i));
+            // additional per-palace palettes
+            lifeBgColorAddr.AddRange(Enumerable.Range(0, 6).Select(i => RomMap.PALACE_PALETTE_TABLE_ENTRANCES + 0x10 * i + 0x03));
+            lifeBgColorAddr.AddRange(Enumerable.Range(0, 6).Select(i => RomMap.PALACE_PALETTE_TABLE_PER_PALACE + 0x10 * i + 0x03));
+        }
+        if (paletteTableAddr == RomMap.GP_PALETTE_TABLE_MAJOR)
+        {
+            lifeBgColorAddr.Add(0x1c48f + 0x03); // palette PPU cmd when fading to Dark Link
+            lifeBgColorAddr.Add(0x1c4a3 + 0x03); // palette PPU cmd when Dark Link has been defeated
+            orangeSpriteColorAddr.Add(paletteTableAddr + 0xa4);
+            orangeSpriteColorAddr.Add(paletteTableAddr + 0xc4);
+            redSpriteColorAddr.Add(paletteTableAddr + 0xa8);
+            blueSpriteColorAddr.Add(paletteTableAddr + 0xac);
+        }
+        if (paletteTableAddr == RomMap.TOWN_PALETTE_TABLE)
+        {
+            var stabguy = paletteTableAddr + 0xac;
+            List<int> wizardAddr = [.. Enumerable.Range(0, 4).Select(i => paletteTableAddr + 0xa4 + 0x10 * i)];
+            orangeSpriteColorAddr.AddRange(wizardAddr);
+            (dark, middle, light) = NES.RollMatchingColorTriple(r, darkRangeFull);
+            ROMData.Put(stabguy + 1, dark);
+            ROMData.Put(stabguy + 2, middle);
+            ROMData.Put(stabguy + 3, light);
+        }
+        if (paletteTableAddr == RomMap.WEST_PALETTE_TABLE || paletteTableAddr == RomMap.EAST_PALETTE_TABLE)
+        {
+            orangeSpriteColorAddr.AddRange(Enumerable.Range(0, 4).Select(i => paletteTableAddr + 0xa4 + 0x10 * i));
+            redSpriteColorAddr.Add(paletteTableAddr + 0xa8);
+            blueSpriteColorAddr.Add(paletteTableAddr + 0xac);
+        }
+
+        List<List<int>> tripples = [orangeSpriteColorAddr, redSpriteColorAddr, blueSpriteColorAddr];
+        List<int> usedColors = [];
+        if (paletteTableAddr == RomMap.TOWN_PALETTE_TABLE)
+        {
+            usedColors.Add(0x22); // blue sky
+        }
+
+        foreach (List<int> list in tripples)
+        {
+            bool isOrange = list == orangeSpriteColorAddr;
+
+            List<int> darkRange = (paletteTableAddr, isOrange) switch
+            {
+                (RomMap.TOWN_PALETTE_TABLE, true) => darkRangeTown.Intersect(darkRangeLife).ToList(),
+                (RomMap.TOWN_PALETTE_TABLE, false) => darkRangeTown,
+                (RomMap.GP_PALETTE_TABLE_MAJOR, true) => darkRangeLife.Where(x => x != 0x14 && x != 0x15).ToList(),
+                (_, true) => darkRangeLife,
+                (_, false) => darkRangeFull,
+            };
+
+            do
+            {
+                (dark, middle, light) = NES.RollMatchingColorTriple(r, darkRange);
+            } while ((dark != 0x2d && usedColors.Contains(dark)) ||
+                     usedColors.Contains(middle) ||
+                     (light != 0x30 && usedColors.Contains(light)));
+
+            // prevent adjacent colors from being picked again
+            usedColors.AddRange(Enumerable.Range(-1, 3).Select(i => dark + i));
+            usedColors.AddRange(Enumerable.Range(-1, 3).Select(i => middle + i));
+            usedColors.AddRange(Enumerable.Range(-1, 3).Select(i => light + i));
+
+            foreach (var i in list)
+            {
+                ROMData.Put(i + 1, dark);
+                ROMData.Put(i + 2, middle);
+                if (list != orangeSpriteColorAddr) { ROMData.Put(i + 3, light); }
+            }
+            if (list == orangeSpriteColorAddr)
+            {
+                foreach (var j in lifeBgColorAddr) { ROMData.Put(j, dark); }
+            }
         }
     }
 

--- a/RandomizerCore/NES.cs
+++ b/RandomizerCore/NES.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Z2Randomizer.RandomizerCore;
 
@@ -32,6 +30,60 @@ public class NES
         Color.FromArgb(237, 234, 164), Color.FromArgb(214, 244, 164), Color.FromArgb(197, 248, 184), Color.FromArgb(190, 246, 211),
         Color.FromArgb(191, 241, 241), Color.FromArgb(185, 185, 185), Color.FromArgb(0, 0, 0),       Color.FromArgb(0, 0, 0),
     ];
+
+    /// this should roll three colors that go well together
+    /// darkRange argument may be passed if you want to specify
+    /// a base range, to avoid conflicts with other colors and such.
+    ///
+    /// (there is definitely room for improvements,
+    ///  allowing complementary colors, for example.)
+    public static (byte dark, byte middle, byte light) RollMatchingColorTriple(Random r, List<int> darkRange)
+    {
+        float hueDistance(float h1, float h2)
+        {
+            float diff = Math.Abs(h1 - h2);
+            return Math.Min(diff, 360f - diff);
+        }
+
+        int dark, middle = 0, light = 0;
+        Color darkColor, middleColor, lightColor;
+        float darkHue, middleHue = 0f, lightHue;
+
+        dark = darkRange.Sample(r);
+        darkColor = NesColors[dark];
+        darkHue = darkColor.GetHue();
+
+        List<int> middleList = new(26);
+        if (dark < 0x0d) { middleList.AddRange(Enumerable.Range(0x11, 0x0c)); }
+        middleList.AddRange(Enumerable.Range(0x21, 0x0c));
+        bool darkIsGrayscale = dark == 0x00 || dark == 0x10 || dark == 0x1d || dark == 0x2d;
+        while (middleList.Count > 0)
+        {
+            middle = middleList.Sample(r);
+            middleColor = NesColors[middle];
+            middleHue = middleColor.GetHue();
+            if (darkIsGrayscale) { break; }
+            if (hueDistance(middleHue, darkHue) < 80f) { break; }
+            middleList.Remove(middle);
+        }
+
+        List<int> lightList = new(26);
+        if (middle < 0x1d) { lightList.AddRange(Enumerable.Range(0x21, 0x0c)); }
+        lightList.AddRange(Enumerable.Range(0x31, 0x0c));
+        while (lightList.Count > 0)
+        {
+            light = lightList.Sample(r);
+            lightColor = NesColors[light];
+            lightHue = lightColor.GetHue();
+            if (light == (int)NesColor.White) { break; }
+            float hueDiffDark = darkIsGrayscale ? 0f : hueDistance(lightHue, darkHue);
+            float hueDiffMiddle = hueDistance(lightHue, middleHue);
+            if (hueDiffDark < 80f && hueDiffMiddle < 80f) { break; }
+            lightList.Remove(middle);
+        }
+
+        return ((byte)dark, (byte)middle, (byte)light);
+    }
 }
 
 /// <summary>

--- a/RandomizerCore/RandomizerConfiguration.cs
+++ b/RandomizerCore/RandomizerConfiguration.cs
@@ -646,9 +646,6 @@ public sealed partial class RandomizerConfiguration : INotifyPropertyChanged
     private bool dashAlwaysOn;
 
     [Reactive]
-    private bool shuffleSpritePalettes;
-
-    [Reactive]
     private bool permanentBeamSword;
 
     //Custom
@@ -724,6 +721,10 @@ public sealed partial class RandomizerConfiguration : INotifyPropertyChanged
     [Reactive]
     [IgnoreInFlags]
     private NesColor shieldTunic;
+
+    [Reactive]
+    [IgnoreInFlags]
+    private bool shuffleSpritePalettes;
 
     [Reactive]
     [IgnoreInFlags]

--- a/RandomizerCore/RomMap.cs
+++ b/RandomizerCore/RomMap.cs
@@ -248,4 +248,12 @@ class RomMap
         // (0x15453, 0x16406), // Thunderbird
         // (0x15454, 0x158aa), // Dark Link
     ];
+
+    public const int WEST_PALETTE_TABLE = 0x401e;
+    public const int EAST_PALETTE_TABLE = 0x801e;
+    public const int TOWN_PALETTE_TABLE = 0xc01e;
+    public const int PALACE_PALETTE_TABLE_MAJOR = 0x1001e;
+    public const int PALACE_PALETTE_TABLE_ENTRANCES = 0x10480;
+    public const int PALACE_PALETTE_TABLE_PER_PALACE = 0x13f10;
+    public const int GP_PALETTE_TABLE_MAJOR = 0x1401e;
 }


### PR DESCRIPTION
- Improve the picked color options a bit
- It now matches the full health bar color with the shuffled sprite portion of the healthbar.
- Don't shuffle what's visible in the dark (we don't touch the enemy attribute tables and the color bit there).
- The option has been moved to be a customize option (it adds a slight self-imposed handicap - but never advantage -  similar to using a custom sprite where you don't know what the enemies or items are.)

Having it is a customize option can easily be changed back if unwanted, but I know some people have wanted to play custom enemy colors in standard flags.