### PR TITLE
Functions for magic cost-dependent logic for spells

### DIFF
--- a/RandomizerCore/RequirementType.cs
+++ b/RandomizerCore/RequirementType.cs
@@ -35,6 +35,33 @@ public enum RequirementType
 
 public static class RequirementTypeExtensions
 {
+    /// Mirror of Collectable.AsRequirement()
+    public static Collectable? AsCollectable(this RequirementType requirementType)
+    {
+        return requirementType switch
+        {
+            RequirementType.JUMP => Collectable.JUMP_SPELL,
+            RequirementType.FAIRY => Collectable.FAIRY_SPELL,
+            RequirementType.UPSTAB => Collectable.UPSTAB,
+            RequirementType.DOWNSTAB => Collectable.DOWNSTAB,
+            RequirementType.KEY => Collectable.MAGIC_KEY,
+            RequirementType.DASH => Collectable.DASH_SPELL,
+            RequirementType.GLOVE => Collectable.GLOVE,
+            RequirementType.REFLECT => Collectable.REFLECT_SPELL,
+            RequirementType.SPELL => Collectable.SPELL_SPELL,
+            RequirementType.TROPHY => Collectable.TROPHY,
+            RequirementType.MEDICINE => Collectable.MEDICINE,
+            RequirementType.CHILD => Collectable.CHILD,
+            RequirementType.MIRROR => Collectable.MIRROR,
+            RequirementType.WATER => Collectable.WATER,
+            RequirementType.FLUTE => Collectable.FLUTE,
+            RequirementType.HAMMER => Collectable.HAMMER,
+            RequirementType.BOOTS => Collectable.BOOTS,
+            RequirementType.BAGU_LETTER => Collectable.BAGUS_NOTE,
+            _ => null
+        };
+    }
+
     public static RequirementType[] UpToXContainers(int x)
     {
         List<RequirementType> requirements = [];
@@ -71,5 +98,28 @@ public static class RequirementTypeExtensions
             requirements.Add(RequirementType.EIGHT_CONTAINERS);
         }
         return requirements.ToArray();
+    }
+
+    public static RequirementType MagicContainerRequirementFromCost(int magicCost)
+    {
+        switch (magicCost)
+        {
+            case <= 16:
+                return RequirementType.ONE_CONTAINER;
+            case <= 32:
+                return RequirementType.TWO_CONTAINERS;
+            case <= 48:
+                return RequirementType.THREE_CONTAINERS;
+            case <= 64:
+                return RequirementType.FOUR_CONTAINERS;
+            case <= 80:
+                return RequirementType.FIVE_CONTAINERS;
+            case <= 96:
+                return RequirementType.SIX_CONTAINERS;
+            case <= 112:
+                return RequirementType.SEVEN_CONTAINERS;
+            default:
+                return RequirementType.EIGHT_CONTAINERS;
+        }
     }
 }

--- a/RandomizerCore/Requirements.cs
+++ b/RandomizerCore/Requirements.cs
@@ -21,6 +21,15 @@ public class Requirements
         {RequirementType.SPELL, [RequirementType.FOUR_CONTAINERS] },
     };
 
+    // the magic level you have to each for each spell to be considered in-logic
+    private static readonly Dictionary<RequirementType, int> ImplicitMagicLevelRequirements = new()
+    {
+        { RequirementType.JUMP, 3 },
+        { RequirementType.FAIRY, 3 },
+        { RequirementType.REFLECT, 4 },
+        { RequirementType.SPELL, 4 },
+    };
+
     public RequirementType[] IndividualRequirements { get; private set; }
     public RequirementType[][] CompositeRequirements { get; private set; }
 
@@ -149,6 +158,73 @@ public class Requirements
         return individualRequirementsSatisfied || compositeRequirementSatisfied;
     }
 
+    public bool AreSatisfiedBy(IEnumerable<RequirementType> requireables, StatRandomizer statRoll)
+    {
+        if (IndividualRequirements.Length + CompositeRequirements.Length == 0)
+        {
+            return true;
+        }
+        var individualRequirementsSatisfied = false;
+        var requirementTypes = requireables as RequirementType[] ?? requireables.ToArray();
+
+        statRoll.AssertHasRandomized();
+
+        bool StatAdjustedContainerRequirementSatisfied(RequirementType requirement)
+        {
+            if (ImplicitMagicLevelRequirements.ContainsKey(requirement))
+            {
+                Collectable collectable = requirement.AsCollectable()!.Value;
+                var requiredLevel = ImplicitMagicLevelRequirements[requirement];
+                var magicCost = statRoll.GetSpellCost(collectable, requiredLevel);
+                var containerRequirement = MagicContainerRequirementFromCost(magicCost);
+                return requirementTypes.Contains(containerRequirement);
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        foreach (var requirement in IndividualRequirements)
+        {
+            if (requirementTypes.Contains(requirement))
+            {
+                individualRequirementsSatisfied = true;
+                if (!StatAdjustedContainerRequirementSatisfied(requirement))
+                {
+                    individualRequirementsSatisfied = false;
+                }
+
+                if (individualRequirementsSatisfied)
+                {
+                    break;
+                }
+            }
+        }
+
+        bool compositeRequirementSatisfied = false;
+        foreach (RequirementType[] compositeRequirement in CompositeRequirements)
+        {
+            if (compositeRequirement.All(i => requireables.Contains(i)))
+            {
+                compositeRequirementSatisfied = true;
+            }
+            foreach (RequirementType component in compositeRequirement)
+            {
+                if (!StatAdjustedContainerRequirementSatisfied(component))
+                {
+                    compositeRequirementSatisfied = false;
+                    break;
+                }
+            }
+            if (compositeRequirementSatisfied == true)
+            {
+                break;
+            }
+        }
+        return individualRequirementsSatisfied || compositeRequirementSatisfied;
+    }
+
     public Requirements WithHardRequirement(RequirementType requirement)
     {
         Requirements newRequirements = new();
@@ -239,6 +315,29 @@ public class Requirements
             }
         }
         return true;
+    }
+
+    public static RequirementType MagicContainerRequirementFromCost(int magicCost)
+    {
+        switch (magicCost)
+        {
+            case <= 16:
+                return RequirementType.ONE_CONTAINER;
+            case <= 32:
+                return RequirementType.TWO_CONTAINERS;
+            case <= 48:
+                return RequirementType.THREE_CONTAINERS;
+            case <= 64:
+                return RequirementType.FOUR_CONTAINERS;
+            case <= 80:
+                return RequirementType.FIVE_CONTAINERS;
+            case <= 96:
+                return RequirementType.SIX_CONTAINERS;
+            case <= 112:
+                return RequirementType.SEVEN_CONTAINERS;
+            default:
+                return RequirementType.EIGHT_CONTAINERS;
+        }
     }
 }
 

--- a/RandomizerCore/Requirements.cs
+++ b/RandomizerCore/Requirements.cs
@@ -24,8 +24,8 @@ public class Requirements
     // the magic level you have to each for each spell to be considered in-logic
     private static readonly Dictionary<RequirementType, int> ImplicitMagicLevelRequirements = new()
     {
-        { RequirementType.JUMP, 3 },
-        { RequirementType.FAIRY, 3 },
+        { RequirementType.JUMP, 2 },
+        { RequirementType.FAIRY, 4 },
         { RequirementType.REFLECT, 4 },
         { RequirementType.SPELL, 4 },
     };

--- a/RandomizerCore/StatRandomizer.cs
+++ b/RandomizerCore/StatRandomizer.cs
@@ -712,4 +712,11 @@ public class StatRandomizer
             BossHpTable[2] = reboHp;
         }
     }
+
+    public int GetSpellCost(Collectable spell, int level)
+    {
+        var spellIndex = spell.VanillaSpellOrder();
+        int index = spellIndex * 8 + level - 1;
+        return MagicEffectivenessTable[index];
+    }
 }


### PR DESCRIPTION
This still needs to be routed in. Currently these functions aren't used anywhere.

One suggestion is rolling StatRandomizer early and then adding it to RandomizerProperties, but I'm not sure.


This can also be expanded on to require different levels for different things. For example, we might only want to require Magic 1 (in logic) to traverse Jump cave, while Magic 3 (or similar) might be the implicit level requirement for palace access.