### PR TITLE
Adds difficulty levels

### DIFF
--- a/CoreSourceGenerator/FlagsSerializeGenerator.cs
+++ b/CoreSourceGenerator/FlagsSerializeGenerator.cs
@@ -85,6 +85,7 @@ public class ReactiveObjectSerializeGenerator : IIncrementalGenerator
             {
                 FieldName = f.Name,
                 FieldType = f.Type.ToDisplayString(),
+                IsDifficultyOnly = HasDifficultyOnlyAttribute(f),
                 IsConditionallyIncluded = HasConditionallyIncludedInFlagsAttribute(f),
                 DefaultValue = GetDefaultValue(f),
                 IsEnum = f.Type.TypeKind == TypeKind.Enum,
@@ -131,6 +132,12 @@ public class ReactiveObjectSerializeGenerator : IIncrementalGenerator
     {
         return field.GetAttributes()
             .Any(attr => attr.AttributeClass?.Name.StartsWith("ConditionallyIncludeInFlags") ?? false);
+    }
+
+    private static bool HasDifficultyOnlyAttribute(IFieldSymbol field)
+    {
+        return field.GetAttributes()
+            .Any(attr => attr.AttributeClass?.Name.StartsWith("DifficultyOnly") ?? false);
     }
 
     private static string GetDefaultValue(IFieldSymbol f)
@@ -209,7 +216,7 @@ public class ReactiveObjectSerializeGenerator : IIncrementalGenerator
             // Look for attributes with "property:" target
             if (attr.AttributeClass == null) continue;
             var attrName = attr.AttributeClass.Name;
-            if (attrName.StartsWith("Reactive") || attrName.StartsWith("CustomFlagSerializer")) continue;
+            if (attrName.StartsWith("Reactive") || attrName.StartsWith("CustomFlagSerializer") || attrName.StartsWith("DifficultyOnly")) continue;
             // if (attrName.EndsWith("Attribute"))
             //     attrName = attrName[..^9];
 
@@ -318,7 +325,7 @@ public class ReactiveObjectSerializeGenerator : IIncrementalGenerator
     private static void GenerateSerializeMethod(StringBuilder sb, List<SerializedFieldInfo> fields, string indent)
     {
         sb.AppendLine();
-        sb.AppendLine($"{indent}    public string Serialize()");
+        sb.AppendLine($"{indent}    private string Serialize(bool includeDifficultyOnly)");
         sb.AppendLine($"{indent}    {{");
         sb.AppendLine($"{indent}        global::Z2Randomizer.RandomizerCore.Flags.FlagBuilder flags = new();");
         sb.AppendLine();
@@ -326,9 +333,19 @@ public class ReactiveObjectSerializeGenerator : IIncrementalGenerator
         foreach (var field in fields)
         {
             var serializeCall = GetSerializeCall(field);
+            var conditions = new List<string>();
+            if (field.IsDifficultyOnly)
+            {
+                conditions.Add("includeDifficultyOnly");
+            }
             if (field.IsConditionallyIncluded)
             {
-                sb.AppendLine($"{indent}        if ({field.FieldName}Included()) {{ ");
+                conditions.Add($"{field.FieldName}Included()");
+            }
+
+            if (conditions.Count > 0)
+            {
+                sb.AppendLine($"{indent}        if ({string.Join(" && ", conditions)}) {{ ");
                 sb.AppendLine($"{indent}            {serializeCall};");
                 sb.AppendLine($"{indent}        }}");
             }
@@ -340,6 +357,16 @@ public class ReactiveObjectSerializeGenerator : IIncrementalGenerator
 
         sb.AppendLine();
         sb.AppendLine($"{indent}        return flags.ToString();");
+        sb.AppendLine($"{indent}    }}");
+        sb.AppendLine();
+        sb.AppendLine($"{indent}    public string Serialize()");
+        sb.AppendLine($"{indent}    {{");
+        sb.AppendLine($"{indent}        return Serialize(includeDifficultyOnly: true);");
+        sb.AppendLine($"{indent}    }}");
+        sb.AppendLine();
+        sb.AppendLine($"{indent}    public string SerializeSharedSeed()");
+        sb.AppendLine($"{indent}    {{");
+        sb.AppendLine($"{indent}        return Serialize(includeDifficultyOnly: false);");
         sb.AppendLine($"{indent}    }}");
     }
 
@@ -579,6 +606,7 @@ public class SerializedFieldInfo
 {
     public string FieldName { get; set; } = string.Empty;
     public string FieldType { get; set; } = string.Empty;
+    public bool IsDifficultyOnly { get; set; }
     public bool IsConditionallyIncluded { get; set; }
     public string? DefaultValue { get; set; }
     public bool IsEnum { get; set; }

--- a/CrossPlatformUI/Lang/Resources.resx
+++ b/CrossPlatformUI/Lang/Resources.resx
@@ -935,6 +935,11 @@ randomly selected between these values (inclusive).
 
 Random selects a random number of starting lives between 2 and 5.</value>
 	</data>
+	<data name="ShareSeedAcrossDifficultyToolTip" xml:space="preserve">
+<value>When enabled, candle/cross, starting hearts, starting lives, starting sword techniques, and attack/life effectiveness no longer change the shared 4-character seed prefix.
+
+Use this only when everyone intentionally wants the same base seed with different handicaps.</value>
+	</data>
 	<data name="RandomFlagRateToolTip" xml:space="preserve">
 <value>For flags set to an indeterminate value (question mark), those flags will be on or off at
 random, at the freqency specified by this flag.</value>

--- a/CrossPlatformUI/Views/Tabs/StartView.axaml
+++ b/CrossPlatformUI/Views/Tabs/StartView.axaml
@@ -79,6 +79,14 @@
           >
               <ToolTip.Tip><TextBlock Text="{x:Static lang:Resources.StartingSpellLimitToolTip}"/></ToolTip.Tip>
           </ComboBox>
+            <Separator/>
+            <CheckBox
+                Margin="14 8 4 8"
+                IsChecked="{Binding Config.ShareSeedAcrossDifficulty}"
+                Content="Allow Difficulty Levels"
+            >
+                <ToolTip.Tip><TextBlock Text="{x:Static lang:Resources.ShareSeedAcrossDifficultyToolTip}"/></ToolTip.Tip>
+            </CheckBox>
         </StackPanel>
         <StackPanel Grid.Column="2">
             <StackPanel Margin="26 16" HorizontalAlignment="Left">

--- a/RandomizerCore/Flags/DifficultyOnlyAttribute.cs
+++ b/RandomizerCore/Flags/DifficultyOnlyAttribute.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Z2Randomizer.RandomizerCore.Flags;
+
+[AttributeUsage(AttributeTargets.Field)]
+public class DifficultyOnlyAttribute : Attribute
+{
+}

--- a/RandomizerCore/Hyrule.cs
+++ b/RandomizerCore/Hyrule.cs
@@ -229,22 +229,26 @@ public class Hyrule
 
             SeedHash = BitConverter.ToInt32(MD5Hash.ComputeHash(Encoding.UTF8.GetBytes(config.Seed!)).AsSpan()[..4]);
             r = new Random(SeedHash);
+            bool shareSeedAcrossDifficulty = config.ShareSeedAcrossDifficulty;
+            Random? difficultyRng = shareSeedAcrossDifficulty ? CreateDifficultyRng(config.Seed) : null;
 
             config.CheckForFlagConflicts();
-            props = config.Export(r);
+            props = config.Export(r, includeDifficulty: !shareSeedAcrossDifficulty);
             //To make sure there isn't any similarity between the spoiler and non-spoiler versions of the seed, spin the RNG a bit.
             if(config.GenerateSpoiler)
             {
                 r.NextBytes(new byte[64]);
+                difficultyRng?.NextBytes(new byte[64]);
             }
 #if UNSAFE_DEBUG
             string export = JsonSerializer.Serialize(props, SourceGenerationContext.Default.RandomizerProperties);
             Debug.WriteLine(export);
 #endif
             Flags = config.SerializeFlags();
+            string sharedSeedFlags = shareSeedAcrossDifficulty ? config.SerializeSharedSeedFlags() : Flags;
 
             using Assembler assembler = CreateAssemblyEngine();
-            logger.Info($"Started generation for flags: {Flags} seed: {config.Seed} seedhash: {SeedHash}");
+            logger.Info($"Started generation for flags: {Flags} sharedseedflags: {sharedSeedFlags} seed: {config.Seed} seedhash: {SeedHash}");
             //character = new Character(props);
             shuffler = new Shuffler(props);
 
@@ -416,9 +420,6 @@ public class Hyrule
             randomizedStats.Randomize(r);
             randomizedStats.Write(ROMData);
 
-            // ideally this should be calculated later, but custom music changes asm patches
-            byte[] randoRomHash = MD5Hash.ComputeHash(ROMData.rawdata);
-
             // ROM changes after this will vary with customize tab options
             //Allows casting magic without requeueing a spell
             if (props.FastCast)
@@ -444,6 +445,8 @@ public class Hyrule
                 return new RandomizerResult(false, null, null, string.Join(Environment.NewLine, rom.messages));
             }
             ROMData = new ROM(rom.romdata);
+            string? debugFile = rom.debugfile;
+            List<string> debugMessages = rom.messages.Select(message => message.ToString()).ToList();
 
             if (randomizeMusic)
             {
@@ -498,31 +501,35 @@ public class Hyrule
                 }
             }
 
-            byte[] finalRNGState = new byte[32];
-
-            r.NextBytes(finalRNGState);
-            byte[] hash = MD5Hash.ComputeHash(Encoding.UTF8.GetBytes(
-                Flags +
-                SeedHash +
-                randoRomHash + // ideally this should be all that's required
-                // Util.ReadAllTextFromFile(config.GetRoomsFile()) +
-                Util.ByteArrayToHexString(finalRNGState)
-            ));
-
             UpdateRom();
 
-            //0 -> W to avoid 0/O confusion, also 6/G so 6 -> X (these are not hypothetical, they have already caused confusion)
-            byte[] z2Hash = ConvertHash(hash);
-            for(int i = 0; i < z2Hash.Length; i++)
+            byte[] z2Hash;
+            if (shareSeedAcrossDifficulty)
             {
-                if(z2Hash[i] == 0xD0)
+                byte[] sharedRngState = new byte[32];
+                r.NextBytes(sharedRngState);
+                byte[] sharedHash = CalculateHash(sharedSeedFlags, SeedHash, MD5Hash.ComputeHash(ROMData.rawdata), sharedRngState);
+
+                var difficultyPatchResult = await ApplyDifficultyOnlySettings(config, difficultyRng!);
+                if (!difficultyPatchResult.success)
                 {
-                    z2Hash[i] = 0xF0;
+                    return new RandomizerResult(false, null, null, difficultyPatchResult.errorMessage);
                 }
-                if (z2Hash[i] == 0xD6)
-                {
-                    z2Hash[i] = 0xF1;
-                }
+                debugFile ??= difficultyPatchResult.debugFile;
+                debugMessages.AddRange(difficultyPatchResult.messages);
+
+                byte[] difficultyRngState = new byte[32];
+                difficultyRng!.NextBytes(difficultyRngState);
+                byte[] finalHash = CalculateHash(Flags, SeedHash, MD5Hash.ComputeHash(ROMData.rawdata), difficultyRngState);
+                z2Hash = CombineHashes(sharedHash, finalHash);
+            }
+            else
+            {
+                byte[] finalRngState = new byte[32];
+                r.NextBytes(finalRngState);
+                byte[] finalHash = CalculateHash(Flags, SeedHash, MD5Hash.ComputeHash(ROMData.rawdata), finalRngState);
+                z2Hash = ConvertHash(finalHash);
+                SanitizeHashCharacters(z2Hash);
             }
 
             ROMData.Put(0x17C2C, z2Hash);
@@ -544,7 +551,7 @@ public class Hyrule
                     File.WriteAllText("rooms.log", sb.ToString());
                 }
             }*/
-            return new RandomizerResult(true, ROMData.rawdata, rom.debugfile, string.Join(Environment.NewLine, rom.messages));
+            return new RandomizerResult(true, ROMData.rawdata, debugFile, string.Join(Environment.NewLine, debugMessages));
         }
         catch(Exception e)
         {
@@ -588,6 +595,111 @@ public class Hyrule
             0xf4,
             (byte)(((inthash >> 25)  & 0x1F) + 0xD0)
         ];
+    }
+
+    private static byte[] CalculateHash(string flags, int seedHash, byte[] romHash, byte[] rngState)
+    {
+        return MD5Hash.ComputeHash(Encoding.UTF8.GetBytes(
+            flags +
+            seedHash +
+            romHash +
+            Util.ByteArrayToHexString(rngState)
+        ));
+    }
+
+    private static Random CreateDifficultyRng(string? seed)
+    {
+        int difficultySeedHash = BitConverter.ToInt32(MD5Hash.ComputeHash(Encoding.UTF8.GetBytes($"{seed}:difficulty")).AsSpan()[..4]);
+        return new Random(difficultySeedHash);
+    }
+
+    private static byte[] CombineHashes(byte[] sharedHash, byte[] finalHash)
+    {
+        byte[] sharedZ2Hash = ConvertHash(sharedHash);
+        byte[] finalZ2Hash = ConvertHash(finalHash);
+        SanitizeHashCharacters(sharedZ2Hash);
+        SanitizeHashCharacters(finalZ2Hash);
+
+        return [
+            sharedZ2Hash[0], 0xF4,
+            sharedZ2Hash[2], 0xF4,
+            sharedZ2Hash[4], 0xF4,
+            sharedZ2Hash[6], 0xF4,
+            finalZ2Hash[8], 0xF4,
+            finalZ2Hash[10]
+        ];
+    }
+
+    private static void SanitizeHashCharacters(byte[] z2Hash)
+    {
+        for (int i = 0; i < z2Hash.Length; i++)
+        {
+            if (z2Hash[i] == 0xD0)
+            {
+                z2Hash[i] = 0xF0;
+            }
+            if (z2Hash[i] == 0xD6)
+            {
+                z2Hash[i] = 0xF1;
+            }
+        }
+    }
+
+    private async Task<(bool success, string? debugFile, List<string> messages, string? errorMessage)> ApplyDifficultyOnlySettings(
+        RandomizerConfiguration config,
+        Random difficultyRng)
+    {
+        config.ApplyDifficultyOnlySettings(props, difficultyRng);
+
+        ROMData.Put(RomMap.START_CANDLE, props.StartCandle ? (byte)1 : (byte)0);
+        ROMData.Put(RomMap.START_CROSS, props.StartCross ? (byte)1 : (byte)0);
+        ROMData.Put(0x1C369, (byte)props.StartLives);
+        ROMData.Put(0x17B12, (byte)((props.StartWithUpstab ? 0x04 : 0) + (props.StartWithDownstab ? 0x10 : 0)));
+
+        StatRandomizer difficultyStats = new(ROMData, props);
+        difficultyStats.RandomizeDifficultyOnly(difficultyRng);
+        difficultyStats.WriteDifficultyOnly(ROMData);
+
+        bool needsDifficultyAsm =
+            props.AttackEffectiveness == AttackEffectiveness.OHKO ||
+            props.ShuffleBossHP != EnemyLifeOption.VANILLA ||
+            props.DripperEnemyOption == DripperEnemyOption.EASIER_GROUND_ENEMIES_FULL_HP ||
+            props.AttackCap < 8 ||
+            props.MagicCap < 8 ||
+            props.LifeCap < 8;
+        if (!needsDifficultyAsm)
+        {
+            return (true, null, new List<string>(), null);
+        }
+
+        using Assembler difficultyAssembler = CreateAssemblyEngine();
+        ROMData.SetLevelCap(difficultyAssembler, props.AttackCap, props.MagicCap, props.LifeCap);
+
+        if (props.ShuffleBossHP != EnemyLifeOption.VANILLA)
+        {
+            ROMData.SetBossHpBarDivisors(difficultyAssembler, difficultyStats);
+        }
+
+        if (props.DripperEnemyOption == DripperEnemyOption.EASIER_GROUND_ENEMIES_FULL_HP)
+        {
+            byte dripperId = ROMData.GetByte(RomMap.DRIPPER_ID);
+            byte dripperHp = difficultyStats.Palace125EnemyHpTable[dripperId];
+            ROMData.SetDripperHp(difficultyAssembler, dripperHp);
+        }
+
+        if (props.AttackEffectiveness == AttackEffectiveness.OHKO)
+        {
+            ROMData.UseOHKOMode(difficultyAssembler);
+        }
+
+        var rom = await ROMData.ApplyAsm(difficultyAssembler);
+        if (!rom.success)
+        {
+            return (false, null, new List<string>(), string.Join(Environment.NewLine, rom.messages));
+        }
+
+        ROMData = new ROM(rom.romdata);
+        return (true, rom.debugfile, rom.messages.Select(message => message.ToString()).ToList(), null);
     }
 
     /*

--- a/RandomizerCore/RandomizerConfiguration.cs
+++ b/RandomizerCore/RandomizerConfiguration.cs
@@ -48,6 +48,22 @@ public sealed partial class RandomizerConfiguration : INotifyPropertyChanged
     ];
 
     [IgnoreInFlags]
+    private readonly static Collectable[] POSSIBLE_SHARED_STARTING_ITEMS = [
+        Collectable.GLOVE,
+        Collectable.RAFT,
+        Collectable.BOOTS,
+        Collectable.FLUTE,
+        Collectable.HAMMER,
+        Collectable.MAGIC_KEY
+    ];
+
+    [IgnoreInFlags]
+    private readonly static Collectable[] POSSIBLE_DIFFICULTY_STARTING_ITEMS = [
+        Collectable.CANDLE,
+        Collectable.CROSS
+    ];
+
+    [IgnoreInFlags]
     private readonly static Collectable[] POSSIBLE_STARTING_SPELLS = [
         Collectable.SHIELD_SPELL,
         Collectable.JUMP_SPELL,
@@ -65,6 +81,7 @@ public sealed partial class RandomizerConfiguration : INotifyPropertyChanged
     private bool shuffleStartingItems;
 
     [Reactive]
+    [DifficultyOnly]
     private bool startWithCandle;
 
     [Reactive]
@@ -80,6 +97,7 @@ public sealed partial class RandomizerConfiguration : INotifyPropertyChanged
     private bool startWithFlute;
 
     [Reactive]
+    [DifficultyOnly]
     private bool startWithCross;
 
     [Reactive]
@@ -145,9 +163,11 @@ public sealed partial class RandomizerConfiguration : INotifyPropertyChanged
     private MaxHeartsOption maxHeartContainers;
 
     [Reactive]
+    [DifficultyOnly]
     private StartingTechs startingTechniques;
 
     [Reactive]
+    [DifficultyOnly]
     private StartingLives startingLives;
 
     [Reactive]
@@ -436,32 +456,38 @@ public sealed partial class RandomizerConfiguration : INotifyPropertyChanged
     private bool shuffleLifeExperience;
 
     [Reactive]
+    [DifficultyOnly]
     [Minimum(1)]
     [Maximum(8)]
     private int attackLevelCap;
 
     [Reactive]
+    [DifficultyOnly]
     [Minimum(1)]
     [Maximum(8)]
     private int magicLevelCap;
 
     [Reactive]
+    [DifficultyOnly]
     [Minimum(1)]
     [Maximum(8)]
     private int lifeLevelCap;
 
     [Reactive]
+    [DifficultyOnly]
     [ConditionallyIncludeInFlags]
     private bool scaleLevelRequirementsToCap;
     public bool scaleLevelRequirementsToCapIncluded() => attackLevelCap < 8 || magicLevelCap < 8 || lifeLevelCap < 8;
 
     [Reactive]
+    [DifficultyOnly]
     private AttackEffectiveness attackEffectiveness;
 
     [Reactive]
     private MagicEffectiveness magicEffectiveness;
 
     [Reactive]
+    [DifficultyOnly]
     private LifeEffectiveness lifeEffectiveness;
 
     //Spells
@@ -508,9 +534,11 @@ public sealed partial class RandomizerConfiguration : INotifyPropertyChanged
     public bool generatorsAlwaysMatchIncluded() => anyEnemiesAreShuffled();
 
     [Reactive]
+    [DifficultyOnly]
     private EnemyLifeOption shuffleEnemyHP;
 
     [Reactive]
+    [DifficultyOnly]
     private EnemyLifeOption shuffleBossHP;
 
     [Reactive]
@@ -523,6 +551,7 @@ public sealed partial class RandomizerConfiguration : INotifyPropertyChanged
     private bool shuffleSwordImmunity;
 
     [Reactive]
+    [DifficultyOnly]
     private XPEffectiveness enemyXPDrops;
 
     //Items
@@ -758,6 +787,9 @@ public sealed partial class RandomizerConfiguration : INotifyPropertyChanged
     [Reactive]
     private bool revealWalkthroughWalls;
 
+    [Reactive]
+    private bool shareSeedAcrossDifficulty;
+
     //Meta
     [Reactive]
     [Required]
@@ -772,6 +804,11 @@ public sealed partial class RandomizerConfiguration : INotifyPropertyChanged
     public String SerializeFlags()
     {
         return Serialize();
+    }
+
+    public string SerializeSharedSeedFlags()
+    {
+        return SerializeSharedSeed();
     }
 
     public RandomizerConfiguration()
@@ -874,7 +911,7 @@ public sealed partial class RandomizerConfiguration : INotifyPropertyChanged
         flags.Append(index, extent);
     }
 
-    public RandomizerProperties Export(Random r)
+    public RandomizerProperties Export(Random r, bool includeDifficulty = true)
     {
         RandomizerProperties properties = new()
         {
@@ -893,7 +930,8 @@ public sealed partial class RandomizerConfiguration : INotifyPropertyChanged
         do // while (!properties.HasEnoughSpaceToAllocateItems())
         {
             //Start Configuration
-            ShuffleStartingCollectables(POSSIBLE_STARTING_ITEMS, startItemsLimit, shuffleStartingItems, properties, r);
+            ShuffleStartingCollectables(includeDifficulty ? POSSIBLE_STARTING_ITEMS : POSSIBLE_SHARED_STARTING_ITEMS,
+                startItemsLimit, shuffleStartingItems, properties, r);
             ShuffleStartingCollectables(POSSIBLE_STARTING_SPELLS, startSpellsLimit, shuffleStartingSpells, properties, r);
 
             List<PalaceStyle> allowedPalaceStyles;
@@ -955,47 +993,7 @@ public sealed partial class RandomizerConfiguration : INotifyPropertyChanged
             AssignPalaceItemCounts(properties, r);
 
             //Other starting attributes
-            int startHeartsMin, startHeartsMax;
-            if (startingHeartContainersMin == null)
-            {
-                startHeartsMin = r.Next(1, 9);
-            }
-            else
-            {
-                startHeartsMin = (int)startingHeartContainersMin;
-            }
-            if (startingHeartContainersMax == null)
-            {
-                startHeartsMax = r.Next(startHeartsMin, 9);
-            }
-            else
-            {
-                startHeartsMax = (int)startingHeartContainersMax;
-            }
-            properties.StartHearts = r.Next(startHeartsMin, startHeartsMax + 1);
-
-            //+1/+2/+3
-            if (maxHeartContainers == MaxHeartsOption.RANDOM)
-            {
-                properties.MaxHearts = r.Next(properties.StartHearts, 9);
-            }
-            else if ((int)maxHeartContainers <= 8)
-            {
-                properties.MaxHearts = (int)maxHeartContainers;
-            }
-            else
-            {
-                int additionalHearts = maxHeartContainers switch
-                {
-                    MaxHeartsOption.PLUS_ONE => 1,
-                    MaxHeartsOption.PLUS_TWO => 2,
-                    MaxHeartsOption.PLUS_THREE => 3,
-                    MaxHeartsOption.PLUS_FOUR => 4,
-                    _ => throw new ImpossibleException("Invalid heart container max configuration")
-                };
-                properties.MaxHearts = Math.Min(properties.StartHearts + additionalHearts, 8);
-            }
-            properties.MaxHearts = Math.Max(properties.MaxHearts, properties.StartHearts);
+            (properties.StartHearts, properties.MaxHearts) = ResolveHeartSettings(r);
 
             int startMagicsMin, startMagicsMax;
             if (startingMagicContainersMin == null)
@@ -1055,51 +1053,11 @@ public sealed partial class RandomizerConfiguration : INotifyPropertyChanged
                 break;
         }
 
-        //If both stabs are random, use the classic weightings
-        if (startingTechniques == StartingTechs.RANDOM)
-        {
-            switch (r.Next(7))
-            {
-                case 0:
-                case 1:
-                case 2:
-                case 3:
-                    properties.StartWithDownstab = false;
-                    properties.StartWithUpstab = false;
-                    break;
-                case 4:
-                    properties.StartWithDownstab = true;
-                    properties.StartWithUpstab = false;
-                    break;
-                case 5:
-                    properties.StartWithDownstab = false;
-                    properties.StartWithUpstab = true;
-                    break;
-                case 6:
-                    properties.StartWithDownstab = true;
-                    properties.StartWithUpstab = true;
-                    break;
-            }
-        }
-        else
-        {
-            properties.StartWithDownstab = startingTechniques.StartWithDownstab();
-            properties.StartWithUpstab = startingTechniques.StartWithUpstab();
-        }
+        ResolveStartingTechniques(properties, r, includeDifficulty);
         properties.SwapUpAndDownStab = swapUpAndDownStab ?? GetIndeterminateFlagValue(r);
 
 
-        properties.StartLives = startingLives switch
-        {
-            StartingLives.Lives1 => 1,
-            StartingLives.Lives2 => 2,
-            StartingLives.Lives3 => 3,
-            StartingLives.Lives4 => 4,
-            StartingLives.Lives5 => 5,
-            StartingLives.Lives8 => 8,
-            StartingLives.Lives16 => 16,
-            _ => r.Next(2, 6)
-        };
+        properties.StartLives = ResolveStartingLives(r, includeDifficulty);
         properties.PermanentBeam = permanentBeamSword;
         properties.UseCommunityText = useCommunityText;
         properties.StartAtk = startingAttackLevel;
@@ -1372,8 +1330,8 @@ public sealed partial class RandomizerConfiguration : INotifyPropertyChanged
         properties.RevealWalkthroughWalls = revealWalkthroughWalls;
 
         //Enemies
-        properties.ShuffleEnemyHP = shuffleEnemyHP;
-        properties.ShuffleBossHP = shuffleBossHP;
+        properties.ShuffleEnemyHP = includeDifficulty ? shuffleEnemyHP : EnemyLifeOption.VANILLA;
+        properties.ShuffleBossHP = includeDifficulty ? shuffleBossHP : EnemyLifeOption.VANILLA;
         properties.ShuffleEnemyStealExp = shuffleXPStealers;
         properties.ShuffleStealExpAmt = shuffleXPStolenAmount;
         properties.ShuffleSwordImmunity = shuffleSwordImmunity;
@@ -1383,22 +1341,22 @@ public sealed partial class RandomizerConfiguration : INotifyPropertyChanged
         properties.DripperEnemyOption = dripperEnemyOption;
         properties.SpellEnemy = randomizeSpellSpellEnemy ?? GetIndeterminateFlagValue(r);
         properties.ShuffleEnemyPalettes = shuffleSpritePalettes;
-        properties.EnemyXPDrops = enemyXPDrops;
+        properties.EnemyXPDrops = includeDifficulty ? enemyXPDrops : XPEffectiveness.VANILLA;
 
         //Levels
         properties.ShuffleAtkExp = shuffleAttackExperience;
         properties.ShuffleMagicExp = shuffleMagicExperience;
         properties.ShuffleLifeExp = shuffleLifeExperience;
-        properties.AttackEffectiveness = attackEffectiveness;
+        properties.AttackEffectiveness = includeDifficulty ? attackEffectiveness : AttackEffectiveness.VANILLA;
         properties.MagicEffectiveness = magicEffectiveness;
-        properties.LifeEffectiveness = lifeEffectiveness;
+        properties.LifeEffectiveness = includeDifficulty ? lifeEffectiveness : LifeEffectiveness.VANILLA;
         properties.ShuffleLifeRefill = shuffleLifeRefillAmount;
         properties.ShuffleSpellLocations = shuffleSpellLocations ?? GetIndeterminateFlagValue(r);
         properties.DisableMagicRecs = disableMagicContainerRequirements ?? GetIndeterminateFlagValue(r);
-        properties.AttackCap = attackLevelCap;
-        properties.MagicCap = magicLevelCap;
-        properties.LifeCap = lifeLevelCap;
-        properties.ScaleLevels = scaleLevelRequirementsToCap;
+        properties.AttackCap = includeDifficulty ? attackLevelCap : 8;
+        properties.MagicCap = includeDifficulty ? magicLevelCap : 8;
+        properties.LifeCap = includeDifficulty ? lifeLevelCap : 8;
+        properties.ScaleLevels = includeDifficulty && scaleLevelRequirementsToCap;
 
         //Items
         properties.ShuffleOverworldItems = shuffleOverworldItems ?? GetIndeterminateFlagValue(r);
@@ -1615,6 +1573,22 @@ public sealed partial class RandomizerConfiguration : INotifyPropertyChanged
         return properties;
     }
 
+    public void ApplyDifficultyOnlySettings(RandomizerProperties properties, Random r)
+    {
+        ShuffleStartingCollectables(POSSIBLE_DIFFICULTY_STARTING_ITEMS, startItemsLimit, shuffleStartingItems, properties, r);
+        ResolveStartingTechniques(properties, r, includeDifficulty: true);
+        properties.StartLives = ResolveStartingLives(r, includeDifficulty: true);
+        properties.AttackCap = attackLevelCap;
+        properties.MagicCap = magicLevelCap;
+        properties.LifeCap = lifeLevelCap;
+        properties.ScaleLevels = scaleLevelRequirementsToCap;
+        properties.AttackEffectiveness = attackEffectiveness;
+        properties.LifeEffectiveness = lifeEffectiveness;
+        properties.ShuffleEnemyHP = shuffleEnemyHP;
+        properties.ShuffleBossHP = shuffleBossHP;
+        properties.EnemyXPDrops = enemyXPDrops;
+    }
+
     public void AssignPalaceItemCounts(RandomizerProperties properties, Random r)
     {
         //I'm not sure whether I like the bias introduced in generating random values and then capping them
@@ -1709,11 +1683,7 @@ public sealed partial class RandomizerConfiguration : INotifyPropertyChanged
     /// scenario should work.
     public void CheckForFlagConflicts()
     {
-        int requiredMinorItemReplacements = 0;
-        if ((startingHeartContainersMax ?? 8) < 4)
-        {
-            requiredMinorItemReplacements = 4 - (startingHeartContainersMax ?? 4);
-        }
+        int requiredMinorItemReplacements = Math.Max(0, 4 - ((startingHeartContainersMax ?? 4)));
         if (CountPossibleMinorItems() < requiredMinorItemReplacements)
         {
             throw new UserFacingException("Impossible Item Flags", "Not enough possible item locations for removed palace items.\n\nAdd more starting items or more palace items.");
@@ -1837,20 +1807,116 @@ public sealed partial class RandomizerConfiguration : INotifyPropertyChanged
         }
     }
 
+    private (int StartHearts, int MaxHearts) ResolveHeartSettings(Random r)
+    {
+        int startHeartsMin = startingHeartContainersMin ?? r.Next(1, 9);
+        int startHeartsMax = startingHeartContainersMax ?? r.Next(startHeartsMin, 9);
+        int startHearts = r.Next(startHeartsMin, startHeartsMax + 1);
+        int maxHearts = ResolveMaxHearts(r, startHearts);
+        maxHearts = Math.Max(maxHearts, startHearts);
+        return (startHearts, maxHearts);
+    }
+
+    private int ResolveMaxHearts(Random r, int startHearts)
+    {
+        if (maxHeartContainers == MaxHeartsOption.RANDOM)
+        {
+            return r.Next(startHearts, 9);
+        }
+        if ((int)maxHeartContainers <= 8)
+        {
+            return (int)maxHeartContainers;
+        }
+
+        int additionalHearts = maxHeartContainers switch
+        {
+            MaxHeartsOption.PLUS_ONE => 1,
+            MaxHeartsOption.PLUS_TWO => 2,
+            MaxHeartsOption.PLUS_THREE => 3,
+            MaxHeartsOption.PLUS_FOUR => 4,
+            _ => throw new ImpossibleException("Invalid heart container max configuration")
+        };
+        return Math.Min(startHearts + additionalHearts, 8);
+    }
+
+    private void ResolveStartingTechniques(RandomizerProperties properties, Random r, bool includeDifficulty)
+    {
+        if (!includeDifficulty)
+        {
+            properties.StartWithDownstab = false;
+            properties.StartWithUpstab = false;
+            return;
+        }
+
+        if (startingTechniques == StartingTechs.RANDOM)
+        {
+            switch (r.Next(7))
+            {
+                case 0:
+                case 1:
+                case 2:
+                case 3:
+                    properties.StartWithDownstab = false;
+                    properties.StartWithUpstab = false;
+                    break;
+                case 4:
+                    properties.StartWithDownstab = true;
+                    properties.StartWithUpstab = false;
+                    break;
+                case 5:
+                    properties.StartWithDownstab = false;
+                    properties.StartWithUpstab = true;
+                    break;
+                case 6:
+                    properties.StartWithDownstab = true;
+                    properties.StartWithUpstab = true;
+                    break;
+            }
+        }
+        else
+        {
+            properties.StartWithDownstab = startingTechniques.StartWithDownstab();
+            properties.StartWithUpstab = startingTechniques.StartWithUpstab();
+        }
+    }
+
+    private int ResolveStartingLives(Random r, bool includeDifficulty)
+    {
+        if (!includeDifficulty)
+        {
+            return 3;
+        }
+
+        return startingLives switch
+        {
+            StartingLives.Lives1 => 1,
+            StartingLives.Lives2 => 2,
+            StartingLives.Lives3 => 3,
+            StartingLives.Lives4 => 4,
+            StartingLives.Lives5 => 5,
+            StartingLives.Lives8 => 8,
+            StartingLives.Lives16 => 16,
+            _ => r.Next(2, 6)
+        };
+    }
+
     private int CountPossibleMinorItems()
     {
         int count = 3, hardStartItemsCount = 0;
 
-        hardStartItemsCount += shuffleStartingItems || startWithCandle ? 1 : 0;
+        hardStartItemsCount += !shareSeedAcrossDifficulty && (shuffleStartingItems || startWithCandle) ? 1 : 0;
         hardStartItemsCount += shuffleStartingItems || startWithBoots ? 1 : 0;
-        hardStartItemsCount += shuffleStartingItems || startWithCross ? 1 : 0;
+        hardStartItemsCount += !shareSeedAcrossDifficulty && (shuffleStartingItems || startWithCross) ? 1 : 0;
         hardStartItemsCount += shuffleStartingItems || startWithFlute ? 1 : 0;
         hardStartItemsCount += shuffleStartingItems || startWithGlove ? 1 : 0;
         hardStartItemsCount += shuffleStartingItems || startWithHammer ? 1 : 0;
         hardStartItemsCount += shuffleStartingItems || startWithMagicKey ? 1 : 0;
         hardStartItemsCount += shuffleStartingItems || startWithRaft ? 1 : 0;
 
-        count += Math.Max(hardStartItemsCount, shuffleStartingItems ? startItemsLimit.AsInt() : 0);
+        int possibleStartItemLimit = shareSeedAcrossDifficulty
+            ? Math.Min(startItemsLimit.AsInt(), POSSIBLE_SHARED_STARTING_ITEMS.Length)
+            : startItemsLimit.AsInt();
+        count += Math.Max(hardStartItemsCount, shuffleStartingItems ? possibleStartItemLimit : 0);
 
         if(includeSpellsInShuffle ?? true)
         {

--- a/RandomizerCore/StatRandomizer.cs
+++ b/RandomizerCore/StatRandomizer.cs
@@ -74,6 +74,19 @@ public class StatRandomizer
         RandomizeEnemyStats(r);
     }
 
+    public void RandomizeDifficultyOnly(Random r)
+    {
+        ExperienceToLevelTable = RandomizeExperienceToLevel(ExperienceToLevelTable, r,
+            [props.ShuffleAtkExp, props.ShuffleMagicExp, props.ShuffleLifeExp],
+            [props.AttackCap, props.MagicCap, props.LifeCap], props.ScaleLevels);
+        RandomizeAttackEffectiveness(r, props.AttackEffectiveness);
+        RandomizeLifeEffectiveness(r, props.LifeEffectiveness);
+        RandomizeRegularEnemyHp(r);
+        RandomizeBossHp(r);
+        FixRebonackHorseKillBug();
+        RandomizeEnemyExperienceDrops(r);
+    }
+
     public void Write(ROM rom)
     {
 #if DEBUG
@@ -87,6 +100,15 @@ public class StatRandomizer
         WriteLifeEffectiveness(rom);
         WriteMagicEffectiveness(rom);
 
+        WriteEnemyHp(rom);
+        WriteEnemyStats(rom);
+    }
+
+    public void WriteDifficultyOnly(ROM rom)
+    {
+        WriteExperienceToLevel(rom);
+        WriteAttackEffectiveness(rom);
+        WriteLifeEffectiveness(rom);
         WriteEnemyHp(rom);
         WriteEnemyStats(rom);
     }
@@ -568,6 +590,16 @@ public class StatRandomizer
         RandomizeEnemyExp(r, BossExpTable, props.EnemyXPDrops); // randomize boss XP separately
     }
 
+    protected void RandomizeEnemyExperienceDrops(Random r)
+    {
+        RandomizeEnemyExpForTable(r, WestEnemyStatsTable, Enemies.WestGroundEnemies, Enemies.WestFlyingEnemies, Enemies.WestGenerators);
+        RandomizeEnemyExpForTable(r, EastEnemyStatsTable, Enemies.EastGroundEnemies, Enemies.EastFlyingEnemies, Enemies.EastGenerators);
+        RandomizeEnemyExpForTable(r, Palace125EnemyStatsTable, Enemies.Palace125GroundEnemies, Enemies.Palace125FlyingEnemies, Enemies.Palace125Generators);
+        RandomizeEnemyExpForTable(r, Palace346EnemyStatsTable, Enemies.Palace346GroundEnemies, Enemies.Palace346FlyingEnemies, Enemies.Palace346Generators);
+        RandomizeEnemyExpForTable(r, GpEnemyStatsTable, Enemies.GPGroundEnemies, Enemies.GPFlyingEnemies, Enemies.GPGenerators);
+        RandomizeEnemyExp(r, BossExpTable, props.EnemyXPDrops);
+    }
+
     protected void RandomizeEnemyAttributes<T>(Random r, byte[] bytes, T[] groundEnemies, T[] flyingEnemies, T[] generators) where T : Enum
     {
         List<T> allEnemies = [.. groundEnemies, .. flyingEnemies, .. generators];
@@ -621,6 +653,17 @@ public class StatRandomizer
             int index = (int)(object)allEnemies[i];
             bytes[index] = enemyBytes1[i];
             bytes[index + 0x24] = enemyBytes2[i];
+        }
+    }
+
+    protected void RandomizeEnemyExpForTable<T>(Random r, byte[] bytes, T[] groundEnemies, T[] flyingEnemies, T[] generators) where T : Enum
+    {
+        List<T> allEnemies = [.. groundEnemies, .. flyingEnemies, .. generators];
+        byte[] enemyBytes = allEnemies.Select(n => bytes[(int)(object)n]).ToArray();
+        RandomizeEnemyExp(r, enemyBytes, props.EnemyXPDrops);
+        for (int i = 0; i < allEnemies.Count; i++)
+        {
+            bytes[(int)(object)allEnemies[i]] = enemyBytes[i];
         }
     }
 

--- a/Tests/FlagsTests.cs
+++ b/Tests/FlagsTests.cs
@@ -156,4 +156,117 @@ public class FlagsTests
         RandomizerConfiguration config2 = new RandomizerConfiguration(MaxRando2025Preset.Preset.SerializeFlags());
         Assert.AreEqual(config.SerializeFlags(), config2.SerializeFlags());
     }
+
+    [TestMethod]
+    public void DifficultyOnlyFlagsDoNotChangeSharedSeedFlags()
+    {
+        RandomizerConfiguration baseConfig = new()
+        {
+            ShareSeedAcrossDifficulty = true
+        };
+        RandomizerConfiguration difficultyConfig = new()
+        {
+            ShareSeedAcrossDifficulty = true,
+            StartWithCandle = true,
+            StartWithCross = true,
+            StartingTechniques = StartingTechs.BOTH,
+            StartingLives = StartingLives.Lives1,
+            AttackLevelCap = 4,
+            MagicLevelCap = 6,
+            LifeLevelCap = 7,
+            ScaleLevelRequirementsToCap = true,
+            AttackEffectiveness = AttackEffectiveness.OHKO,
+            LifeEffectiveness = LifeEffectiveness.INVINCIBLE,
+            ShuffleEnemyHP = EnemyLifeOption.WIDE,
+            ShuffleBossHP = EnemyLifeOption.MEDIUM_HIGH,
+            EnemyXPDrops = XPEffectiveness.NONE
+        };
+
+        Assert.AreNotEqual(baseConfig.SerializeFlags(), difficultyConfig.SerializeFlags());
+        Assert.AreEqual(baseConfig.SerializeSharedSeedFlags(), difficultyConfig.SerializeSharedSeedFlags());
+    }
+
+    [TestMethod]
+    public void SharedSeedExportIgnoresDifficultyOnlySettings()
+    {
+        RandomizerConfiguration config = new()
+        {
+            ShareSeedAcrossDifficulty = true,
+            StartWithCandle = true,
+            StartWithCross = true,
+            StartingTechniques = StartingTechs.BOTH,
+            StartingLives = StartingLives.Lives1,
+            AttackLevelCap = 4,
+            MagicLevelCap = 6,
+            LifeLevelCap = 7,
+            ScaleLevelRequirementsToCap = true,
+            AttackEffectiveness = AttackEffectiveness.OHKO,
+            LifeEffectiveness = LifeEffectiveness.INVINCIBLE,
+            ShuffleEnemyHP = EnemyLifeOption.WIDE,
+            ShuffleBossHP = EnemyLifeOption.MEDIUM_HIGH,
+            EnemyXPDrops = XPEffectiveness.NONE
+        };
+
+        RandomizerProperties properties = config.Export(new Random(1234), includeDifficulty: false);
+
+        Assert.IsFalse(properties.StartCandle);
+        Assert.IsFalse(properties.StartCross);
+        Assert.IsFalse(properties.StartWithDownstab);
+        Assert.IsFalse(properties.StartWithUpstab);
+        Assert.AreEqual(3, properties.StartLives);
+        Assert.AreEqual(8, properties.AttackCap);
+        Assert.AreEqual(8, properties.MagicCap);
+        Assert.AreEqual(8, properties.LifeCap);
+        Assert.IsFalse(properties.ScaleLevels);
+        Assert.AreEqual(AttackEffectiveness.VANILLA, properties.AttackEffectiveness);
+        Assert.AreEqual(LifeEffectiveness.VANILLA, properties.LifeEffectiveness);
+        Assert.AreEqual(EnemyLifeOption.VANILLA, properties.ShuffleEnemyHP);
+        Assert.AreEqual(EnemyLifeOption.VANILLA, properties.ShuffleBossHP);
+        Assert.AreEqual(XPEffectiveness.VANILLA, properties.EnemyXPDrops);
+    }
+
+    [TestMethod]
+    public void StartingHeartContainersChangeSharedSeedFlags()
+    {
+        RandomizerConfiguration baseConfig = new()
+        {
+            ShareSeedAcrossDifficulty = true
+        };
+        RandomizerConfiguration heartConfig = new()
+        {
+            ShareSeedAcrossDifficulty = true,
+            StartingHeartContainersMin = 7,
+            StartingHeartContainersMax = 7
+        };
+
+        Assert.AreNotEqual(baseConfig.SerializeSharedSeedFlags(), heartConfig.SerializeSharedSeedFlags());
+    }
+
+    [TestMethod]
+    public void SharedSeedExportKeepsStartingHeartContainers()
+    {
+        RandomizerConfiguration config = new()
+        {
+            ShareSeedAcrossDifficulty = true,
+            StartingHeartContainersMin = 7,
+            StartingHeartContainersMax = 7
+        };
+
+        RandomizerProperties properties = config.Export(new Random(1234), includeDifficulty: false);
+
+        Assert.AreEqual(7, properties.StartHearts);
+    }
+
+    [TestMethod]
+    public void ShareSeedAcrossDifficultyRoundTripsInFlags()
+    {
+        RandomizerConfiguration config = new()
+        {
+            ShareSeedAcrossDifficulty = true
+        };
+
+        RandomizerConfiguration config2 = new(config.SerializeFlags());
+
+        Assert.IsTrue(config2.ShareSeedAcrossDifficulty);
+    }
 }


### PR DESCRIPTION
Specifies certain flags as "difficulty only" to have the same logical seed with varying difficulty levels.  When the "Allow Difficulty Levels" flag is enabled, the hash will be split.  The first 4 characters will be determined by the non-difficulty flags, eg palace structure, item locations, etc, to verify that racers have the same game to play.  The remaining 2 characters will be calculated after difficulty settings are applied.