### PR TITLE
Fix duplicate room prevention for shape-first palaces

### DIFF
--- a/RandomizerCore/Sidescroll/RoomPool.cs
+++ b/RandomizerCore/Sidescroll/RoomPool.cs
@@ -370,4 +370,10 @@ public class RoomPool
             return roomType == exitType;
         }).ToList();
     }
+
+    public void RefillNormalRoomsForExitType(RoomPool rooms, RoomExitType exitType)
+    {
+        var originalRooms = rooms.GetNormalRoomsForExitType(exitType);
+        NormalRooms.AddRange(originalRooms);
+    }
 }

--- a/RandomizerCore/Sidescroll/RoomPool.cs
+++ b/RandomizerCore/Sidescroll/RoomPool.cs
@@ -1,6 +1,4 @@
-﻿using NLog.Targets;
-using SD.Tools.Algorithmia.GeneralDataStructures;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -28,35 +26,6 @@ public class RoomPool
 #pragma warning restore CS8618 
 
     protected static readonly IEqualityComparer<byte[]> byteArrayEqualityComparer = new Util.StandardByteArrayEqualityComparer();
-
-    public RoomPool(RoomPool target)
-    {
-        NormalRooms.AddRange(target.NormalRooms);
-        Entrances.AddRange(target.Entrances);
-        BossRooms.AddRange(target.BossRooms);
-        TbirdRooms.AddRange(target.TbirdRooms);
-        ItemRooms.AddRange(target.ItemRooms);
-        VanillaBossRoom = target.VanillaBossRoom;
-        DefaultUpEntrance = target.DefaultUpEntrance;
-        DefaultDownBossRoom = target.DefaultDownBossRoom;
-        foreach (var pair in target.LinkedRooms)
-        {
-            LinkedRooms.Add(pair.Key, pair.Value);
-        }
-        foreach (var direction in target.ItemRoomsByDirection.Keys)
-        {
-            ItemRoomsByDirection[direction] = target.ItemRoomsByDirection[direction];
-        }
-        foreach (var shape in target.ItemRoomsByShape.Keys)
-        {
-            var ls = target.ItemRoomsByShape[shape];
-            ItemRoomsByShape[shape] = ls.ToList();
-        }
-        foreach (var key in target.DefaultStubsByDirection.Keys)
-        {
-            DefaultStubsByDirection.Add(key, target.DefaultStubsByDirection[key]);
-        }
-    }
 
     public RoomPool(PalaceRooms palaceRooms, int palaceNumber, RandomizerProperties props)
     {
@@ -273,6 +242,39 @@ public class RoomPool
         if (!props.IncludeExpertRooms)
         {
             RemoveRooms(room => room.Tags != null && room.Tags.Contains("Expert"));
+        }
+    }
+
+    /// Initializes a new <see cref="RoomPool"/> by copying an existing instance.
+    /// Collections are shallow-cloned. Contained <see cref="Room"/> objects are
+    /// shared between instances.
+    public RoomPool(RoomPool target)
+    {
+        NormalRooms.AddRange(target.NormalRooms);
+        Entrances.AddRange(target.Entrances);
+        BossRooms.AddRange(target.BossRooms);
+        TbirdRooms.AddRange(target.TbirdRooms);
+        ItemRooms.AddRange(target.ItemRooms);
+
+        VanillaBossRoom = target.VanillaBossRoom;
+        DefaultUpEntrance = target.DefaultUpEntrance;
+        DefaultDownBossRoom = target.DefaultDownBossRoom;
+
+        foreach (var pair in target.LinkedRooms)
+        {
+            LinkedRooms.Add(pair.Key, pair.Value);
+        }
+        foreach (var pair in target.ItemRoomsByDirection)
+        {
+            ItemRoomsByDirection[pair.Key] = (TableWeightedRandom<Room>)pair.Value.Clone();
+        }
+        foreach (var pair in target.ItemRoomsByShape)
+        {
+            ItemRoomsByShape[pair.Key] = [.. pair.Value];
+        }
+        foreach (var pair in target.DefaultStubsByDirection)
+        {
+            DefaultStubsByDirection.Add(pair.Key, pair.Value);
         }
     }
 

--- a/RandomizerCore/Sidescroll/RoomPool.cs
+++ b/RandomizerCore/Sidescroll/RoomPool.cs
@@ -40,96 +40,19 @@ public class RoomPool
             //GP also has vanilla rooms added.
             || (palaceNumber == 7 && !props.AllowVanillaRooms && !props.AllowV4Rooms && props.AllowV5_0Rooms))
         {
-            Entrances.AddRange(palaceRooms.Entrances(RoomGroup.VANILLA)
-                .Where(i => i.PalaceNumber == null || i.PalaceNumber == palaceNumber).ToList());
-            BossRooms.AddRange(palaceRooms.BossRooms(RoomGroup.VANILLA)
-                .Where(i => (i.PalaceNumber == null && palaceNumber < 6) || i.PalaceNumber == palaceNumber).ToList());
-            TbirdRooms.AddRange(palaceRooms.ThunderBirdRooms(RoomGroup.VANILLA)
-                .Where(i => i.PalaceNumber == null || i.PalaceNumber == palaceNumber).ToList());
-            ItemRooms.AddRange(palaceRooms.ItemRooms(RoomGroup.VANILLA)
-                .Where(i => i.PalaceNumber == null || i.PalaceNumber == palaceNumber).ToList());
-            foreach (var room in palaceRooms.LinkedRooms(RoomGroup.VANILLA))
-            {
-                LinkedRooms.Add(room.Key, room.Value);
-            }
-            foreach (var direction in DirectionExtensions.ITEM_ROOM_ORIENTATIONS)
-            {
-                foreach (Room room in palaceRooms.ItemRoomsByDirection(RoomGroup.VANILLA, direction).ToList())
-                {
-                    bool[] weights = [room.HasUpExit, room.HasDownExit, room.HasLeftExit, room.HasRightExit, room.IsDropZone];
-                    roomDirectionWeightsByDirection[direction].Add((room, 5 - weights.Count(i => i)));
-                }
-            }
-            foreach(var shape in palaceRooms.ItemRooms(RoomGroup.VANILLA).Select(i => i.CategorizeExits()).Distinct())
-            {
-                var newRooms = palaceRooms.ItemRoomsByShape(RoomGroup.VANILLA, shape);
-                var ls = ItemRoomsByShape.GetValueOrDefault(shape, []);
-                ls.AddRange(newRooms);
-                ItemRoomsByShape[shape] = ls;
-            }
+            AddRoomGroup(palaceRooms, RoomGroup.VANILLA, palaceNumber, roomDirectionWeightsByDirection);
         }
 
         if (props.AllowV4Rooms)
         {
-            Entrances.AddRange(palaceRooms.Entrances(RoomGroup.V4_0)
-                .Where(i => i.PalaceNumber == null || i.PalaceNumber == palaceNumber).ToList());
-            BossRooms.AddRange(palaceRooms.BossRooms(RoomGroup.V4_0)
-                .Where(i => (i.PalaceNumber == null && palaceNumber < 6) || i.PalaceNumber == palaceNumber).ToList());
-            TbirdRooms.AddRange(palaceRooms.ThunderBirdRooms(RoomGroup.V4_0)
-                .Where(i => i.PalaceNumber == null || i.PalaceNumber == palaceNumber).ToList());
-            ItemRooms.AddRange(palaceRooms.ItemRooms(RoomGroup.V4_0)
-                .Where(i => i.PalaceNumber == null || i.PalaceNumber == palaceNumber).ToList());
-            foreach (var room in palaceRooms.LinkedRooms(RoomGroup.V4_0))
-            {
-                LinkedRooms.Add(room.Key, room.Value);
-            }
-            foreach (var direction in DirectionExtensions.ITEM_ROOM_ORIENTATIONS)
-            {
-                foreach (Room room in palaceRooms.ItemRoomsByDirection(RoomGroup.V4_0, direction).ToList())
-                {
-                    bool[] weights = [room.HasUpExit, room.HasDownExit, room.HasLeftExit, room.HasRightExit, room.IsDropZone];
-                    roomDirectionWeightsByDirection[direction].Add((room, 5 - weights.Count(i => i)));
-                }
-            }
-            foreach (var shape in palaceRooms.ItemRooms(RoomGroup.V4_0).Select(i => i.CategorizeExits()).Distinct())
-            {
-                var newRooms = palaceRooms.ItemRoomsByShape(RoomGroup.V4_0, shape);
-                var ls = ItemRoomsByShape.GetValueOrDefault(shape, []);
-                ls.AddRange(newRooms);
-                ItemRoomsByShape[shape] = ls;
-            }
+            AddRoomGroup(palaceRooms, RoomGroup.V4_0, palaceNumber, roomDirectionWeightsByDirection);
         }
 
         if (props.AllowV5_0Rooms)
         {
-            Entrances.AddRange(palaceRooms.Entrances(RoomGroup.V5_0)
-                .Where(i => i.PalaceNumber == null || i.PalaceNumber == palaceNumber).ToList());
-            BossRooms.AddRange(palaceRooms.BossRooms(RoomGroup.V5_0)
-                .Where(i => (i.PalaceNumber == null && palaceNumber < 6) || i.PalaceNumber == palaceNumber).ToList());
-            TbirdRooms.AddRange(palaceRooms.ThunderBirdRooms(RoomGroup.V5_0)
-                .Where(i => i.PalaceNumber == null || i.PalaceNumber == palaceNumber).ToList());
-            ItemRooms.AddRange(palaceRooms.ItemRooms(RoomGroup.V5_0)
-                .Where(i => i.PalaceNumber == null || i.PalaceNumber == palaceNumber).ToList());
-            foreach (var room in palaceRooms.LinkedRooms(RoomGroup.V5_0))
-            {
-                LinkedRooms.Add(room.Key, room.Value);
-            }
-            foreach (var direction in DirectionExtensions.ITEM_ROOM_ORIENTATIONS)
-            {
-                foreach (Room room in palaceRooms.ItemRoomsByDirection(RoomGroup.V5_0, direction).ToList())
-                {
-                    bool[] weights = [room.HasUpExit, room.HasDownExit, room.HasLeftExit, room.HasRightExit, room.IsDropZone];
-                    roomDirectionWeightsByDirection[direction].Add((room, 5 - weights.Count(i => i)));
-                }
-            }
-            foreach (var shape in palaceRooms.ItemRooms(RoomGroup.V5_0).Select(i => i.CategorizeExits()).Distinct())
-            {
-                var newRooms = palaceRooms.ItemRoomsByShape(RoomGroup.V5_0, shape);
-                var ls = ItemRoomsByShape.GetValueOrDefault(shape, []);
-                ls.AddRange(newRooms);
-                ItemRoomsByShape[shape] = ls;
-            }
+            AddRoomGroup(palaceRooms, RoomGroup.V5_0, palaceNumber, roomDirectionWeightsByDirection);
         }
+
         //If we are using these categorized exits to cap paths, there needs to always be a path of each type
         //Since vanilla and 4.0 don't normally contain up/down elevator deadends, we add some dummy ones
         DefaultStubsByDirection.Add(RoomExitType.DEADEND_EXIT_DOWN, palaceRooms.NormalPalaceRoomsByGroup(RoomGroup.STUBS).Where(i => i.HasDownExit).First());
@@ -278,6 +201,35 @@ public class RoomPool
         }
     }
 
+    private void AddRoomGroup(PalaceRooms palaceRooms, RoomGroup group, int palaceNumber, Dictionary<Direction, List<(Room, int)>> roomDirectionWeightsByDirection)
+    {
+        Entrances.AddRange(palaceRooms.Entrances(group).Where(room => (room.PalaceNumber == null && palaceNumber < 7) || room.PalaceNumber == palaceNumber));
+        ItemRooms.AddRange(palaceRooms.ItemRooms(group).Where(room => (room.PalaceNumber == null && palaceNumber < 7) || room.PalaceNumber == palaceNumber));
+        BossRooms.AddRange(palaceRooms.BossRooms(group).Where(room => (room.PalaceNumber == null && palaceNumber < 6) || room.PalaceNumber == palaceNumber));
+        TbirdRooms.AddRange(palaceRooms.ThunderBirdRooms(group).Where(room => (room.PalaceNumber == null && palaceNumber == 7) || room.PalaceNumber == palaceNumber));
+        foreach (var pair in palaceRooms.LinkedRooms(group))
+        {
+            LinkedRooms[pair.Key] = pair.Value;
+        }
+        foreach (var direction in DirectionExtensions.ITEM_ROOM_ORIENTATIONS)
+        {
+            foreach (var room in palaceRooms.ItemRoomsByDirection(group, direction))
+            {
+                // give item rooms lower weights if they have more exits
+                bool[] hasExits = [room.HasUpExit, room.HasDownExit, room.HasLeftExit, room.HasRightExit, room.IsDropZone];
+                roomDirectionWeightsByDirection[direction].Add((room, 5 - hasExits.Count(i => i)));
+            }
+        }
+        var exitTypes = palaceRooms.ItemRooms(group).Select(r => r.CategorizeExits()).Distinct();
+        foreach (var shape in exitTypes)
+        {
+            var newRooms = palaceRooms.ItemRoomsByShape(group, shape);
+            var ls = ItemRoomsByShape.GetValueOrDefault(shape, []);
+            ls.AddRange(newRooms);
+            ItemRoomsByShape[shape] = ls;
+        }
+    }
+
     public IEnumerable<RoomExitType> GetItemRoomShapes()
     {
         var keys = ItemRoomsByShape.Keys;
@@ -402,7 +354,7 @@ public class RoomPool
 
             value.Add(room);
         }
-        
+
         return categorizedRooms;
     }
 

--- a/RandomizerCore/Sidescroll/ShapeFirstCoordinatePalaceGenerator.cs
+++ b/RandomizerCore/Sidescroll/ShapeFirstCoordinatePalaceGenerator.cs
@@ -17,7 +17,6 @@ public abstract class ShapeFirstCoordinatePalaceGenerator() : CoordinatePalaceGe
     {
         bool duplicateProtection = (props.NoDuplicateRooms || props.NoDuplicateRoomsBySideview) && AllowDuplicatePrevention(props, palaceNumber);
         Palace palace = new(palaceNumber);
-        Dictionary<RoomExitType, List<Room>> roomsByExitType;
         RoomPool roomPool = new(rooms);
         var itemRoomSelector = GetItemRoomSelectionStrategy();
         // var palaceGroup = Util.AsPalaceGrouping(palaceNumber);
@@ -71,9 +70,18 @@ public abstract class ShapeFirstCoordinatePalaceGenerator() : CoordinatePalaceGe
             return palace;
         }
 
-        //Add rooms
-        roomsByExitType = roomPool.CategorizeNormalRoomExits(true);
+        var roomsByExitTypeUnmodified = roomPool.CategorizeNormalRoomExits();
         Dictionary<RoomExitType, bool> stubOnlyExitTypes = new();
+        bool IsStubOnly(RoomExitType exitType)
+        {
+            if (stubOnlyExitTypes.TryGetValue(exitType, out var cached)) { return cached; }
+            roomsByExitTypeUnmodified.TryGetValue(exitType, out var roomList);
+            bool stubOnly = roomList == null || roomList.Count == 0;
+            stubOnlyExitTypes[exitType] = stubOnly;
+            return stubOnly;
+        }
+
+        //Add rooms
         foreach (KeyValuePair<Coord, RoomExitType> item in shape.OrderBy(i => i.Key.X).ThenByDescending(i => i.Key.Y))
         {
             if (prepopulatedCoordinates.Contains(item.Key))
@@ -83,28 +91,19 @@ public abstract class ShapeFirstCoordinatePalaceGenerator() : CoordinatePalaceGe
             var (x, y) = item.Key;
             RoomExitType roomExitType = item.Value;
 
-            bool stubOnly;
-            List<Room>? roomCandidates;
+            bool stubOnly = IsStubOnly(roomExitType);
+            List<Room>? roomCandidates = stubOnly ? null : roomPool.GetNormalRoomsForExitType(roomExitType);
             Room? newRoom = null;
-            if (!stubOnlyExitTypes.TryGetValue(roomExitType, out stubOnly))
-            {
-                roomsByExitType.TryGetValue(roomExitType, out roomCandidates);
-                stubOnly = roomCandidates == null || roomCandidates.Count == 0;
-                stubOnlyExitTypes[roomExitType] = stubOnly;
-            }
-            else
-            {
-                roomCandidates = stubOnly ? null : roomsByExitType.GetValueOrDefault(roomExitType);
-            }
+
             if (!stubOnly)
             {
                 Debug.Assert(roomCandidates != null);
                 if (duplicateProtection && roomCandidates!.Count == 0)
                 {
+                    logger.Debug($"Shape-first palace ran out of rooms of exit type: {roomExitType} in palace {palaceNumber}. Starting to use duplicate rooms.");
+                    roomPool.RefillNormalRoomsForExitType(rooms, roomExitType);
                     roomCandidates = roomPool.GetNormalRoomsForExitType(roomExitType, true);
                     Debug.Assert(roomCandidates.Count() > 0);
-                    roomsByExitType[roomExitType] = roomCandidates;
-                    logger.Debug($"RandomWalk ran out of rooms of exit type: {roomExitType} in palace {palaceNumber}. Starting to use duplicate rooms.");
                 }
                 roomCandidates!.FisherYatesShuffle(r);
                 Room? upRoom = palace.AllRooms.FirstOrDefault(i => i.coords == new Coord(x, y + 1));


### PR DESCRIPTION
Chadbert pointed out to me that he got a Tower palace with unreasonbly many duplicate rooms. After investigating, it turns out the code no longer actually avoids duplicate rooms for shape-first palaces.

1st problem:
roomsByExitType was set outside of the shape for-loop. Then roomPool.RemoveDuplicates was called inside the loop, which modified roomPool. However, that didn't matter since roomsByExitType was never re-created from the roomPool.

2nd problem:
The code used to rely on roomPool.NormalRooms to refill the rooms-by-shape list. Since roomPool.RemoveDuplicates now mutates this field, it was just going to return an empty list at that point.

Because the RoomPool code was messy, I also had to do some refactoring.


I think it should be merged before the tournament because it's a bug that impacts a lot of the palace styles used.

(I'd recommend reviewing commit-by-commit.)