### PR TITLE
Get the full WebAssembly pipeline working for much smaller web build

### DIFF
--- a/.github/workflows/build-branch-for-web.yaml
+++ b/.github/workflows/build-branch-for-web.yaml
@@ -49,6 +49,6 @@ jobs:
         with:
           name: Z2Randomizer-${{ inputs.version }}-${{ matrix.platform.name }}
           path: |
-            CrossPlatformUI.Browser/bin/Release/net10.0-browser/browser-wasm/AppBundle/
+            CrossPlatformUI.Browser/bin/Release/net10.0-browser/publish
             !**/*.pdb
 

--- a/CrossPlatformUI.Browser/.gitignore
+++ b/CrossPlatformUI.Browser/.gitignore
@@ -1,1 +1,5 @@
+wwwroot/Asm
+wwwroot/js65
+wwwroot/Sprites
 wwwroot/ips-manifest.txt
+wwwroot/PalaceRooms.json

--- a/CrossPlatformUI.Browser/CrossPlatformUI.Browser.csproj
+++ b/CrossPlatformUI.Browser/CrossPlatformUI.Browser.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.WebAssembly">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net10.0-browser</TargetFramework>
@@ -17,13 +17,14 @@
         <Configurations>Debug;Release;Unsafe Debug</Configurations>
 
         <Platforms>AnyCPU</Platforms>
-<!--        <TrimMode>partial</TrimMode>-->
+        <PublishTrimmed>false</PublishTrimmed>
+        <TrimMode>copyused</TrimMode>
 <!--        <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>-->
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+<!--    <PropertyGroup Condition="'$(Configuration)' == 'Release'">
         <RunAOTCompilation>true</RunAOTCompilation>
-    </PropertyGroup>
+    </PropertyGroup>-->
 
     <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
         <DebugType>full</DebugType>
@@ -44,17 +45,35 @@
     <ItemGroup>
         <WasmExtraFilesToDeploy Include="wwwroot\**" />
     </ItemGroup>
-    <ItemGroup>
-        <WasmExtraFilesToDeploy Include="..\RandomizerCore\Sprites\**" TargetPath="Sprites\%(Filename)%(Extension)" />
-        <WasmExtraFilesToDeploy Include="..\RandomizerCore\PalaceRooms.json" />
-        <WasmExtraFilesToDeploy Include="..\RandomizerCore\Asm\**" TargetPath="Asm\%(RecursiveDir)\%(Filename)%(Extension)" />
-    </ItemGroup>
+    <Target Name="CopyAssetsToLocalWwwRoot" BeforeTargets="BeforeBuild;AssignTargetPaths">
+        <ItemGroup>
+            <!-- Define the external source items -->
+            <ExternalSprites Include="..\RandomizerCore\Sprites\**" />
+            <ExternalJson Include="..\RandomizerCore\PalaceRooms.json" />
+            <ExternalAsm Include="..\RandomizerCore\Asm\**" />
+
+            <!-- Tell Visual Studio to watch them for changes -->
+            <UpToDateCheckInput Include="@(ExternalSprites);@(ExternalJson);@(ExternalAsm)" />
+        </ItemGroup>
+
+        <Copy SourceFiles="@(ExternalSprites)"
+              DestinationFiles="@(ExternalSprites -> 'wwwroot\Sprites\%(RecursiveDir)%(Filename)%(Extension)')"
+              SkipUnchangedFiles="true" />
+        <Copy SourceFiles="@(ExternalJson)"
+              DestinationFiles="wwwroot\PalaceRooms.json"
+              SkipUnchangedFiles="true" />
+        <Copy SourceFiles="@(ExternalAsm)"
+              DestinationFiles="@(ExternalAsm -> 'wwwroot\Asm\%(RecursiveDir)%(Filename)%(Extension)')"
+              SkipUnchangedFiles="true" />
+    </Target>
+
     <ItemGroup>
         <IpsFiles Include="..\RandomizerCore\Sprites\*.ips" />
     </ItemGroup>
     <ItemGroup>
       <None Remove="wwwroot\index.html" />
     </ItemGroup>
+    
     <Target Name="GenerateIpsManifest" AfterTargets="Build">
         <WriteLinesToFile
             File="wwwroot\ips-manifest.txt"
@@ -62,9 +81,16 @@
             Overwrite="true" />
     </Target>
 
+    <Target Name="CopyJs65Assets" AfterTargets="ResolvePackageAssets">
+        <ItemGroup>
+            <Js65Files Include="$(Pkgjs65_browser)\assets\js65\**\*.*" />
+        </ItemGroup>
+        <Copy SourceFiles="@(Js65Files)" DestinationFolder="$(MSBuildProjectDirectory)\wwwroot\js65\%(RecursiveDir)" SkipUnchangedFiles="true" />
+    </Target>
+
     <ItemGroup>
         <PackageReference Include="Avalonia.Browser" Version="$(AvaloniaVersion)" />
-        <PackageReference Include="js65.browser" Version="$(Js65Version)" />
+        <PackageReference Include="js65.browser" Version="$(Js65Version)" GeneratePathProperty="true" />
     </ItemGroup>
 
     <ItemGroup>
@@ -74,8 +100,4 @@
     <ItemGroup>
         <ProjectReference Include="..\CrossPlatformUI\CrossPlatformUI.csproj" />
     </ItemGroup>
-
-<!--    <ItemGroup>-->
-<!--        <TrimmerRootAssembly Include="RandomizerCore" />-->
-<!--    </ItemGroup>-->
 </Project>

--- a/CrossPlatformUI.Browser/CrossPlatformUI.Browser.csproj
+++ b/CrossPlatformUI.Browser/CrossPlatformUI.Browser.csproj
@@ -17,14 +17,13 @@
         <Configurations>Debug;Release;Unsafe Debug</Configurations>
 
         <Platforms>AnyCPU</Platforms>
-        <PublishTrimmed>false</PublishTrimmed>
-        <TrimMode>copyused</TrimMode>
+        <TrimMode>partial</TrimMode>
 <!--        <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>-->
     </PropertyGroup>
 
-<!--    <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <PropertyGroup Condition="'$(Configuration)' == 'Release'">
         <RunAOTCompilation>true</RunAOTCompilation>
-    </PropertyGroup>-->
+    </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
         <DebugType>full</DebugType>

--- a/CrossPlatformUI.Browser/CrossPlatformUI.Browser.csproj
+++ b/CrossPlatformUI.Browser/CrossPlatformUI.Browser.csproj
@@ -19,6 +19,9 @@
         <Platforms>AnyCPU</Platforms>
         <TrimMode>partial</TrimMode>
 <!--        <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>-->
+
+		<CompressionEnabled>false</CompressionEnabled>
+		<BlazorEnableCompression>false</BlazorEnableCompression>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'Release'">

--- a/CrossPlatformUI.Browser/wwwroot/main.js
+++ b/CrossPlatformUI.Browser/wwwroot/main.js
@@ -26,6 +26,12 @@ function showError(msg) {
     // identify runtime/assembly payloads
     const isBootResource = (url, res) => {
         const u = (typeof url === "string" ? url : url.url || "").toLowerCase();
+        
+        // Skip hot reload endpoints entirely
+        if (u.includes("hotreload")) {
+            return false;
+        }
+
         const ext = /\.(wasm|dll|pdb|dat|gz|br|json|blat|bundle)$/.test(u);
         const frameworkPath = u.includes("/_framework/") || u.includes("dotnet.") || u.includes("icudt");
         const ct = res?.headers?.get("content-type") || "";


### PR DESCRIPTION
Previously the web version was using a frankenbuild that wasn't doing important WASM steps like compressing files. This PR gets it properly set up for a WASM build. This reduces the files published from 61.7 MB to 14.2 MB.

Currently trimming is disabled. It may be possible to shrink it another few megs by getting trimming working, but it will take additional work.